### PR TITLE
fix(player): eliminate video jumping, stall watchdog, seek bar jitter

### DIFF
--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -22,6 +22,10 @@ class AppConfig {
 
   /// Returns [path] unchanged if it is already an absolute URL
   /// (has a scheme and host). Otherwise prefixes it with [oracleUrl].
+  ///
+  /// Also rewrites absolute resolver endpoints (starting with `/v1/`)
+  /// that point to the loopback or same host to use [oracleUrl]'s
+  /// scheme, host, and port, to handle port/proxy differences.
   static String resolveOmssUrl(String path) {
     final String trimmed = path.trim();
     if (trimmed.isEmpty) {
@@ -29,6 +33,20 @@ class AppConfig {
     }
     final Uri? uri = Uri.tryParse(trimmed);
     if (uri != null && uri.hasScheme && uri.host.isNotEmpty) {
+      final Uri baseUri = Uri.parse(oracleUrl);
+      final String host = uri.host.toLowerCase();
+      final String baseHost = baseUri.host.toLowerCase();
+      if (uri.path.startsWith('/v1/') &&
+          (host == baseHost ||
+           host == '127.0.0.1' ||
+           host == 'localhost' ||
+           host == '10.0.2.2')) {
+        return uri.replace(
+          scheme: baseUri.scheme,
+          host: baseUri.host,
+          port: baseUri.port,
+        ).toString();
+      }
       return trimmed;
     }
     if (trimmed.startsWith('/')) {

--- a/lib/screens/player_screen.dart
+++ b/lib/screens/player_screen.dart
@@ -227,6 +227,19 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
   /// top-right is the only affordance until the user taps it.
   bool _controlsLocked = false;
 
+  /// True once the video surface has decoded at least one frame.
+  /// The [Video] widget stays invisible until this flag so the surface
+  /// never flashes an empty / wrong-ratio frame that causes the visual
+  /// "jumping" reported by users.
+  bool _hasFirstVideoFrame = false;
+
+  /// Fires after [_player.open] if no video frame arrives within a
+  /// deadline.  Automatically retries with software decoding.
+  Timer? _videoStallTimer;
+
+  /// True after one software-decode retry so we don't loop forever.
+  bool _hwdecFallbackAttempted = false;
+
   void _debugPlayer(String event, [Map<String, Object?> data = const {}]) {
     final Map<String, Object?> fields = <String, Object?>{
       'ready': _playerReady,
@@ -366,6 +379,7 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
     if (!mounted) {
       return;
     }
+    _videoStallTimer?.cancel();
     setState(() {
       _sourceSwitching = false;
       _pendingSourceId = null;
@@ -375,6 +389,8 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
       _hasPlaybackError = false;
       _playbackError = null;
       _buffering = true;
+      _hasFirstVideoFrame = false;
+      _hwdecFallbackAttempted = false;
       // Restore subtitle state from the preserved args so the user keeps
       // their active track across source switches.
       _activeExternalOfferId = widget.args.preservedExternalOfferId;
@@ -430,6 +446,7 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
     _progressTimer?.cancel();
     _subtitleToastTimer?.cancel();
     _gestureHintTimer?.cancel();
+    _videoStallTimer?.cancel();
     _playerSettingsLabelRev.dispose();
     unawaited(_restoreScreenBrightness());
     SystemChrome.setPreferredOrientations(DeviceOrientation.values);
@@ -1027,6 +1044,20 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
           _controlsVisible = true;
         });
       }),
+      _player.stream.width.listen((int? value) {
+        if (!mounted) {
+          return;
+        }
+        if (value != null && value > 0 && !_hasFirstVideoFrame) {
+          _videoStallTimer?.cancel();
+          _debugPlayer('stream.firstVideoFrame', <String, Object?>{
+            'width': value,
+          });
+          setState(() {
+            _hasFirstVideoFrame = true;
+          });
+        }
+      }),
     ]);
   }
 
@@ -1068,6 +1099,7 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
         ..._debugSourceFields(),
       });
 
+      _videoStallTimer?.cancel();
       if (mounted) {
         setState(() {
           _openingStream = true;
@@ -1077,6 +1109,7 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
           _buffering = true;
           _controlsLocked = false;
           _controlsVisible = true;
+          _hasFirstVideoFrame = false;
         });
         _debugPlayer('open.surface_requested');
         await WidgetsBinding.instance.endOfFrame;
@@ -1091,6 +1124,7 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
       if (platform is NativePlayer) {
         if (enableHw) {
           await platform.setProperty('hwdec', 'mediacodec');
+          await platform.setProperty('hwdec-codecs', 'h264');
         } else {
           await platform.setProperty('hwdec', 'no');
         }
@@ -1140,6 +1174,13 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
         _buffering = false;
         _playbackError = null;
       });
+      // Start video-stall watchdog — if no video frame arrives within
+      // the deadline, retry with software decoding.
+      _videoStallTimer?.cancel();
+      _videoStallTimer = Timer(
+        const Duration(seconds: 8),
+        _handleVideoStall,
+      );
       _debugPlayer('open.ready', <String, Object?>{
         'elapsedMs': openWatch.elapsedMilliseconds,
       });
@@ -1203,12 +1244,12 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
     final List<StreamCaption> captions = response.subtitles
         .map((OmssSubtitle s) {
           return StreamCaption(
-            url: s.url,
+            url: s.resolvedUrl,
             language: _languageCodeFromLabel(s.label),
             type: s.format,
             label: s.label,
             raw: <String, dynamic>{
-              'url': s.url,
+              'url': s.resolvedUrl,
               'label': s.label,
               'format': s.format,
             },
@@ -1224,9 +1265,9 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
       stream: StreamPlayback(
         id: 'omss-${source.providerId}',
         type: source.type,
-        playlist: source.type == 'hls' ? source.url : null,
+        playlist: source.type == 'hls' ? source.resolvedUrl : null,
         proxiedPlaylist: null,
-        playbackUrl: source.url,
+        playbackUrl: source.resolvedUrl,
         playbackType: source.type,
         selectedQuality: source.quality,
         qualities: const <String, StreamQuality>{},
@@ -1306,6 +1347,49 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
       setState(() {});
       _debugPlayer('recover.done');
     }
+  }
+
+  /// Watchdog callback: if no video frame has arrived after opening a
+  /// stream, retry with software decoding (hardware codecs sometimes
+  /// silently fail on HEVC / VP9 while audio continues).
+  void _handleVideoStall() {
+    if (!mounted || _hasFirstVideoFrame) {
+      return;
+    }
+    _debugPlayer('stall.check', <String, Object?>{
+      'playing': _playing,
+      'hwdecFallbackAttempted': _hwdecFallbackAttempted,
+    });
+    if (!_hwdecFallbackAttempted && _playing) {
+      // Audio is playing but video never decoded — likely a hardware
+      // codec failure.  Retry the stream with software decoding.
+      _debugPlayer('stall.hwdec_fallback');
+      _hwdecFallbackAttempted = true;
+      unawaited(_retryWithSoftwareDecoding());
+    } else {
+      // Either already retried or player isn't even playing yet.
+      // Show the surface as-is so controls remain functional.
+      _debugPlayer('stall.force_show');
+      if (mounted) {
+        setState(() {
+          _hasFirstVideoFrame = true;
+        });
+      }
+    }
+  }
+
+  Future<void> _retryWithSoftwareDecoding() async {
+    _debugPlayer('retry_sw.begin');
+    final PlatformPlayer? platform = _player.platform;
+    if (platform is NativePlayer) {
+      try {
+        await platform.setProperty('hwdec', 'no');
+      } catch (e) {
+        _debugPlayer('retry_sw.hwdec_error', <String, Object?>{'error': '$e'});
+      }
+    }
+    final int resumePos = _position.inSeconds;
+    await _openStream(resumeFrom: resumePos > 0 ? resumePos : null);
   }
 
   Future<void> _persistProgress({bool refresh = true}) async {
@@ -2759,21 +2843,20 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
                 _PlayerBackdrop(mediaItem: widget.args.mediaItem),
                 Positioned.fill(
                   child: IgnorePointer(
-                    child: (_playerReady || _openingStream)
-                        ? Video(
-                            controller: _videoController,
-                            controls: NoVideoControls,
-                            fit: BoxFit.contain,
-                            fill: AppColors.blackC50,
-                            // Flutter-side subtitle render. media_kit pushes
-                            // the active text track to `_player.stream.subtitle`
-                            // and SubtitleView paints it; the visible instance
-                            // is stacked *above* [PlayerControls] so it is not
-                            // covered by the control chrome.
-                            subtitleViewConfiguration:
-                                _buildSubtitleViewConfiguration(
-                              ref,
-                              displayVisible: false,
+                    child: _playerReady
+                        ? AnimatedOpacity(
+                            opacity: _hasFirstVideoFrame ? 1.0 : 0.0,
+                            duration: const Duration(milliseconds: 300),
+                            child: Video(
+                              controller: _videoController,
+                              controls: NoVideoControls,
+                              fit: BoxFit.contain,
+                              fill: AppColors.blackC50,
+                              subtitleViewConfiguration:
+                                  _buildSubtitleViewConfiguration(
+                                ref,
+                                displayVisible: false,
+                              ),
                             ),
                           )
                         : const SizedBox.shrink(),

--- a/lib/utils/player_native_tune.dart
+++ b/lib/utils/player_native_tune.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:media_kit/media_kit.dart';
-import 'package:pstream_android/storage/local_storage.dart';
+
 
 /// Optional libmpv tuning for Android native [Player] (playback parity / headroom).
 ///
@@ -16,8 +16,8 @@ Future<void> applyNativePlaybackTune(Player player) async {
   try {
     await platform.setProperty('volume-max', '150');
     await platform.setProperty('demuxer-readahead-secs', '20');
-    final bool enableHw = LocalStorage.getHardwareAccelerationEnabled();
-    await platform.setProperty('hwdec', enableHw ? 'mediacodec' : 'no');
+    // hwdec is now set exclusively by _openStream in player_screen.dart
+    // before _player.open() to avoid the race condition of setting it twice.
   } catch (error, stackTrace) {
     debugPrint('applyNativePlaybackTune: $error\n$stackTrace');
   }

--- a/lib/widgets/player_controls.dart
+++ b/lib/widgets/player_controls.dart
@@ -292,7 +292,7 @@ class PlayerInfoPill extends StatelessWidget {
   }
 }
 
-class _SeekBar extends StatelessWidget {
+class _SeekBar extends StatefulWidget {
   const _SeekBar({
     required this.position,
     required this.duration,
@@ -306,15 +306,39 @@ class _SeekBar extends StatelessWidget {
   final Future<void> Function(double fraction) onSeek;
 
   @override
+  State<_SeekBar> createState() => _SeekBarState();
+}
+
+class _SeekBarState extends State<_SeekBar> {
+  /// True while the user is actively dragging the seek thumb.
+  /// During a drag the thumb tracks [_dragFraction] instead of the
+  /// stream position, eliminating the jitter from ~4 Hz rebuilds.
+  bool _isDragging = false;
+  double _dragFraction = 0;
+
+  double get _playedFraction {
+    final double totalMs = widget.duration.inMilliseconds.toDouble();
+    if (totalMs <= 0) {
+      return 0;
+    }
+    return (widget.position.inMilliseconds / totalMs).clamp(0, 1).toDouble();
+  }
+
+  double get _bufferedFraction {
+    final double totalMs = widget.duration.inMilliseconds.toDouble();
+    if (totalMs <= 0) {
+      return 0;
+    }
+    return (widget.buffered.inMilliseconds / totalMs).clamp(0, 1).toDouble();
+  }
+
+  /// The fraction used for the played bar and thumb position.
+  double get _displayFraction => _isDragging ? _dragFraction : _playedFraction;
+
+  @override
   Widget build(BuildContext context) {
     final _PlayerControlMetrics metrics = _PlayerControlMetrics.of(context);
-    final double totalMs = duration.inMilliseconds.toDouble();
-    final double bufferedFraction = totalMs <= 0
-        ? 0
-        : (buffered.inMilliseconds / totalMs).clamp(0, 1).toDouble();
-    final double playedFraction = totalMs <= 0
-        ? 0
-        : (position.inMilliseconds / totalMs).clamp(0, 1).toDouble();
+    final double displayFraction = _displayFraction;
 
     return RepaintBoundary(
       child: LayoutBuilder(
@@ -326,14 +350,36 @@ class _SeekBar extends StatelessWidget {
                   (details.localPosition.dx / constraints.maxWidth)
                       .clamp(0, 1)
                       .toDouble();
-              onSeek(fraction);
+              widget.onSeek(fraction);
+            },
+            onHorizontalDragStart: (DragStartDetails details) {
+              setState(() {
+                _isDragging = true;
+                _dragFraction =
+                    (details.localPosition.dx / constraints.maxWidth)
+                        .clamp(0, 1)
+                        .toDouble();
+              });
             },
             onHorizontalDragUpdate: (DragUpdateDetails details) {
-              final double fraction =
-                  (details.localPosition.dx / constraints.maxWidth)
-                      .clamp(0, 1)
-                      .toDouble();
-              onSeek(fraction);
+              setState(() {
+                _dragFraction =
+                    (details.localPosition.dx / constraints.maxWidth)
+                        .clamp(0, 1)
+                        .toDouble();
+              });
+            },
+            onHorizontalDragEnd: (DragEndDetails details) {
+              final double finalFraction = _dragFraction;
+              setState(() {
+                _isDragging = false;
+              });
+              widget.onSeek(finalFraction);
+            },
+            onHorizontalDragCancel: () {
+              setState(() {
+                _isDragging = false;
+              });
             },
             child: SizedBox(
               height: metrics.seekBarHeight,
@@ -347,40 +393,53 @@ class _SeekBar extends StatelessWidget {
                         color: AppColors.progressBackground.withValues(
                           alpha: 0.35,
                         ),
-                        borderRadius: BorderRadius.circular(metrics.trackRadius),
+                        borderRadius:
+                            BorderRadius.circular(metrics.trackRadius),
                       ),
                     ),
                     FractionallySizedBox(
-                      widthFactor: bufferedFraction,
+                      widthFactor: _bufferedFraction,
                       child: Container(
                         height: metrics.seekTrackHeight,
                         decoration: BoxDecoration(
                           color: AppColors.semanticSilverC400,
-                          borderRadius: BorderRadius.circular(metrics.trackRadius),
+                          borderRadius:
+                              BorderRadius.circular(metrics.trackRadius),
                         ),
                       ),
                     ),
                     FractionallySizedBox(
-                      widthFactor: playedFraction,
+                      widthFactor: displayFraction,
                       child: Container(
                         height: metrics.seekTrackHeight,
                         decoration: BoxDecoration(
                           color: AppColors.progressFilled,
-                          borderRadius: BorderRadius.circular(metrics.trackRadius),
+                          borderRadius:
+                              BorderRadius.circular(metrics.trackRadius),
                         ),
                       ),
                     ),
                     Positioned(
-                      left:
-                          (constraints.maxWidth * playedFraction) -
+                      left: (constraints.maxWidth * displayFraction) -
                           metrics.thumbRadius,
                       top: -metrics.thumbRadius,
                       child: Container(
                         width: metrics.thumbSize,
                         height: metrics.thumbSize,
-                        decoration: const BoxDecoration(
+                        decoration: BoxDecoration(
                           color: AppColors.progressFilled,
                           shape: BoxShape.circle,
+                          boxShadow: _isDragging
+                              ? <BoxShadow>[
+                                  BoxShadow(
+                                    color:
+                                        AppColors.progressFilled.withValues(
+                                      alpha: 0.4,
+                                    ),
+                                    blurRadius: 8,
+                                  ),
+                                ]
+                              : null,
                         ),
                       ),
                     ),


### PR DESCRIPTION
- Gate Video widget visibility on first decoded frame via AnimatedOpacity fade-in (fixes violent poster→video jump on playback start)
- Add 8s video-stall watchdog: auto-retries with software decoding if hardware codec stalls (fixes audio-only / frozen video)
- Restrict hwdec-codecs to h264 to avoid HEVC/VP9 hw decode failures
- Remove duplicate hwdec set in applyNativePlaybackTune (race condition)
- Convert SeekBar to StatefulWidget with local drag state (fixes jitter)
- Rewrite OMSS proxy URLs to public port 3002 in app_config.dart