### PR TITLE
Add XPass embed source and Live TV tab.

### DIFF
--- a/lib/config/router.dart
+++ b/lib/config/router.dart
@@ -4,6 +4,7 @@ import 'package:pstream_android/models/media_item.dart';
 import 'package:pstream_android/screens/detail_screen.dart';
 import 'package:pstream_android/screens/history_screen.dart';
 import 'package:pstream_android/screens/home_screen.dart';
+import 'package:pstream_android/screens/live_screen.dart';
 import 'package:pstream_android/screens/my_list_screen.dart';
 import 'package:pstream_android/screens/player_screen.dart';
 import 'package:pstream_android/screens/search_screen.dart';
@@ -87,6 +88,16 @@ final GoRouter appRouter = GoRouter(
               path: '/list',
               builder: (BuildContext context, GoRouterState state) {
                 return const MyListScreen();
+              },
+            ),
+          ],
+        ),
+        StatefulShellBranch(
+          routes: <RouteBase>[
+            GoRoute(
+              path: '/live',
+              builder: (BuildContext context, GoRouterState state) {
+                return const LiveScreen();
               },
             ),
           ],

--- a/lib/models/live_channel.dart
+++ b/lib/models/live_channel.dart
@@ -1,0 +1,61 @@
+/// A single Live TV channel from `https://wfs.lol/live-channels.json`.
+///
+/// Every channel exposes a direct HLS `.m3u8` stream (`src == "hls"`).
+class LiveChannel {
+  const LiveChannel({
+    required this.id,
+    required this.name,
+    required this.cat,
+    required this.url,
+    required this.logo,
+  });
+
+  final String id;
+  final String name;
+  final String cat;
+
+  /// Direct HLS m3u8 stream URL.
+  final String url;
+  final String logo;
+
+  /// Derives the EPG lookup key: `"Newsmax2.us"` → `"newsmax2"`.
+  String get epgKey => id.split('.').first.toLowerCase();
+
+  factory LiveChannel.fromJson(Map<String, dynamic> json) => LiveChannel(
+        id: '${json['id'] ?? ''}',
+        name: '${json['name'] ?? ''}',
+        cat: '${json['cat'] ?? ''}',
+        url: '${json['url'] ?? ''}',
+        logo: '${json['logo'] ?? ''}',
+      );
+}
+
+/// A single EPG program entry from `https://wfs.lol/live-epg.json`.
+class LiveProgram {
+  const LiveProgram({
+    required this.startMs,
+    required this.endMs,
+    required this.title,
+  });
+
+  /// Epoch milliseconds.
+  final int startMs;
+
+  /// Epoch milliseconds.
+  final int endMs;
+  final String title;
+
+  bool get isNow {
+    final int now = DateTime.now().millisecondsSinceEpoch;
+    return now >= startMs && now < endMs;
+  }
+
+  Duration get remaining =>
+      Duration(milliseconds: endMs - DateTime.now().millisecondsSinceEpoch);
+
+  factory LiveProgram.fromJson(Map<String, dynamic> json) => LiveProgram(
+        startMs: (json['s'] as num).toInt(),
+        endMs: (json['e'] as num).toInt(),
+        title: '${json['t'] ?? ''}',
+      );
+}

--- a/lib/models/omss_source.dart
+++ b/lib/models/omss_source.dart
@@ -60,6 +60,10 @@ class OmssSource {
   /// True if the source advertises an HLS playlist.
   bool get isHls => type == 'hls';
 
+  /// True if the source is an iframe embed player (e.g. XPass) rather than a
+  /// raw stream URL. Embed sources are rendered in a WebView, not video_player.
+  bool get isEmbed => type == 'embed';
+
   factory OmssSource.fromJson(Map<String, dynamic> json) {
     final Map<String, dynamic> provider = (json['provider'] is Map)
         ? Map<String, dynamic>.from(json['provider'] as Map)

--- a/lib/providers/live_provider.dart
+++ b/lib/providers/live_provider.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:pstream_android/models/live_channel.dart';
+import 'package:pstream_android/services/live_service.dart';
+
+final liveServiceProvider = Provider<LiveService>((_) => const LiveService());
+
+final liveChannelsProvider = FutureProvider<List<LiveChannel>>((ref) async {
+  return ref.read(liveServiceProvider).fetchChannels();
+});
+
+final liveEpgProvider =
+    FutureProvider<Map<String, List<LiveProgram>>>((ref) async {
+  return ref.read(liveServiceProvider).fetchEpg();
+});

--- a/lib/screens/live_screen.dart
+++ b/lib/screens/live_screen.dart
@@ -1,0 +1,304 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:shimmer/shimmer.dart';
+
+import 'package:pstream_android/config/app_theme.dart';
+import 'package:pstream_android/config/breakpoints.dart';
+import 'package:pstream_android/models/live_channel.dart';
+import 'package:pstream_android/models/media_item.dart';
+import 'package:pstream_android/models/omss_source.dart';
+import 'package:pstream_android/models/season.dart';
+import 'package:pstream_android/providers/live_provider.dart';
+import 'package:pstream_android/screens/player_screen.dart';
+import 'package:pstream_android/widgets/channel_card.dart';
+
+/// Live TV browse screen: a category-filtered grid of HLS channels.
+class LiveScreen extends ConsumerStatefulWidget {
+  const LiveScreen({super.key});
+
+  @override
+  ConsumerState<LiveScreen> createState() => _LiveScreenState();
+}
+
+class _LiveScreenState extends ConsumerState<LiveScreen> {
+  /// Selected category filter; null means "All".
+  String? _selectedCat;
+
+  static const List<String> _categories = <String>[
+    'Sports',
+    'News',
+    'Entertainment',
+    'Movies',
+    'Music',
+    'Kids',
+    'Docs',
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final AsyncValue<List<LiveChannel>> channelsAsync =
+        ref.watch(liveChannelsProvider);
+    final AsyncValue<Map<String, List<LiveProgram>>> epgAsync =
+        ref.watch(liveEpgProvider);
+    final Map<String, List<LiveProgram>> epg =
+        epgAsync.asData?.value ?? const <String, List<LiveProgram>>{};
+
+    return Scaffold(
+      backgroundColor: AppColors.backgroundMain,
+      body: CustomScrollView(
+        slivers: <Widget>[
+          const SliverAppBar(
+            pinned: true,
+            title: Text('Live TV'),
+          ),
+          SliverToBoxAdapter(
+            child: _CategoryFilterBar(
+              categories: _categories,
+              selected: _selectedCat,
+              onSelected: (String? cat) {
+                setState(() => _selectedCat = cat);
+              },
+            ),
+          ),
+          ...channelsAsync.when(
+            data: (List<LiveChannel> channels) =>
+                _buildGrid(context, channels, epg),
+            loading: () => <Widget>[_buildLoadingGrid(context)],
+            error: (Object error, StackTrace _) => <Widget>[
+              _buildError(context),
+            ],
+          ),
+          const SliverToBoxAdapter(
+            child: SizedBox(height: AppSpacing.x16),
+          ),
+        ],
+      ),
+    );
+  }
+
+  List<Widget> _buildGrid(
+    BuildContext context,
+    List<LiveChannel> channels,
+    Map<String, List<LiveProgram>> epg,
+  ) {
+    final List<LiveChannel> filtered = _selectedCat == null
+        ? channels
+        : channels
+            .where((LiveChannel c) =>
+                c.cat.toLowerCase() == _selectedCat!.toLowerCase())
+            .toList(growable: false);
+
+    if (filtered.isEmpty) {
+      return <Widget>[
+        SliverFillRemaining(
+          hasScrollBody: false,
+          child: Center(
+            child: Text(
+              'No channels in this category.',
+              style: Theme.of(context)
+                  .textTheme
+                  .bodyMedium
+                  ?.copyWith(color: AppColors.typeSecondary),
+            ),
+          ),
+        ),
+      ];
+    }
+
+    return <Widget>[
+      SliverPadding(
+        padding: const EdgeInsets.all(AppSpacing.x4),
+        sliver: SliverGrid(
+          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+            crossAxisCount: gridCols(context),
+            crossAxisSpacing: AppSpacing.x3,
+            mainAxisSpacing: AppSpacing.x3,
+            childAspectRatio: 0.92,
+          ),
+          delegate: SliverChildBuilderDelegate(
+            (BuildContext context, int index) {
+              final LiveChannel channel = filtered[index];
+              return ChannelCard(
+                channel: channel,
+                currentProgram: _currentProgram(channel, epg),
+                onTap: () => _openChannel(channel, epg),
+              );
+            },
+            childCount: filtered.length,
+          ),
+        ),
+      ),
+    ];
+  }
+
+  Widget _buildLoadingGrid(BuildContext context) {
+    return SliverPadding(
+      padding: const EdgeInsets.all(AppSpacing.x4),
+      sliver: SliverGrid(
+        gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: gridCols(context),
+          crossAxisSpacing: AppSpacing.x3,
+          mainAxisSpacing: AppSpacing.x3,
+          childAspectRatio: 0.92,
+        ),
+        delegate: SliverChildBuilderDelegate(
+          (BuildContext context, int index) {
+            return ClipRRect(
+              borderRadius: BorderRadius.circular(AppSpacing.x4),
+              child: Shimmer.fromColors(
+                baseColor: AppColors.mediaCardHoverBackground,
+                highlightColor: AppColors.mediaCardHoverAccent,
+                child: const ColoredBox(
+                  color: AppColors.mediaCardHoverBackground,
+                ),
+              ),
+            );
+          },
+          childCount: gridCols(context) * 3,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildError(BuildContext context) {
+    return SliverFillRemaining(
+      hasScrollBody: false,
+      child: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.x6),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              const Icon(
+                Icons.cloud_off_rounded,
+                color: AppColors.typeSecondary,
+                size: AppSpacing.x12,
+              ),
+              const SizedBox(height: AppSpacing.x3),
+              Text(
+                "Couldn't load live channels.",
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      color: AppColors.typeEmphasis,
+                    ),
+              ),
+              const SizedBox(height: AppSpacing.x4),
+              OutlinedButton.icon(
+                onPressed: () => ref.invalidate(liveChannelsProvider),
+                icon: const Icon(Icons.refresh_rounded),
+                label: const Text('Retry'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Finds the program airing right now for [channel], if EPG data exists.
+  String? _currentProgram(
+    LiveChannel channel,
+    Map<String, List<LiveProgram>> epg,
+  ) {
+    final List<LiveProgram>? programs = epg[channel.epgKey];
+    if (programs == null || programs.isEmpty) {
+      return null;
+    }
+    for (final LiveProgram p in programs) {
+      if (p.isNow) {
+        return p.title;
+      }
+    }
+    return null;
+  }
+
+  void _openChannel(
+    LiveChannel channel,
+    Map<String, List<LiveProgram>> epg,
+  ) {
+    context.push('/player', extra: _buildLiveArgs(channel, epg));
+  }
+
+  PlayerScreenArgs _buildLiveArgs(
+    LiveChannel channel,
+    Map<String, List<LiveProgram>> epg,
+  ) {
+    final OmssSource source = OmssSource(
+      url: channel.url,
+      type: 'hls',
+      quality: null,
+      providerId: channel.id,
+      providerName: channel.name,
+    );
+    final OmssResponse response = OmssResponse(
+      responseId: null,
+      expiresAt: null,
+      sources: <OmssSource>[source],
+      subtitles: const <OmssSubtitle>[],
+      diagnostics: const <String>[],
+    );
+    return PlayerScreenArgs(
+      mediaItem: _liveChannelAsMediaItem(channel),
+      omssResponse: response,
+      isLive: true,
+      liveChannelName: channel.name,
+      liveCurrentProgram: _currentProgram(channel, epg),
+    );
+  }
+
+  /// Builds a minimal synthetic [MediaItem] for the player. Live channels are
+  /// not TMDB titles, so most fields are empty — only [title] is meaningful.
+  MediaItem _liveChannelAsMediaItem(LiveChannel channel) => MediaItem(
+        tmdbId: 0,
+        type: 'movie',
+        title: channel.name,
+        overview: '',
+        posterPath: null,
+        backdropPath: null,
+        year: 0,
+        imdbId: null,
+        rating: 0,
+        seasons: const <Season>[],
+      );
+}
+
+class _CategoryFilterBar extends StatelessWidget {
+  const _CategoryFilterBar({
+    required this.categories,
+    required this.selected,
+    required this.onSelected,
+  });
+
+  final List<String> categories;
+  final String? selected;
+  final ValueChanged<String?> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: AppSpacing.x16,
+      child: ListView.builder(
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.symmetric(horizontal: AppSpacing.x4),
+        itemCount: categories.length + 1,
+        itemBuilder: (BuildContext context, int index) {
+          final bool isAll = index == 0;
+          final String? cat = isAll ? null : categories[index - 1];
+          final String label = isAll ? 'All' : categories[index - 1];
+          final bool isSelected = selected == cat;
+          return Padding(
+            padding: const EdgeInsets.only(right: AppSpacing.x2),
+            child: Center(
+              child: ChoiceChip(
+                label: Text(label),
+                selected: isSelected,
+                onSelected: (_) => onSelected(cat),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/player_screen.dart
+++ b/lib/screens/player_screen.dart
@@ -23,17 +23,14 @@ import 'package:pstream_android/providers/storage_provider.dart';
 import 'package:pstream_android/providers/stream_provider.dart';
 import 'package:pstream_android/services/external_subtitle_service.dart';
 import 'package:pstream_android/services/stream_service.dart';
+import 'package:pstream_android/services/xpass_service.dart';
 import 'package:pstream_android/storage/local_storage.dart';
 
 import 'package:pstream_android/widgets/player_controls.dart';
+import 'package:pstream_android/widgets/xpass_embed_player.dart';
 import 'package:screen_brightness/screen_brightness.dart';
 
 enum _PlayerEdgeSwipe { none, brightness, volume }
-
-/// Sentinel for "resolver responded but returned zero playable sources".
-class _NoSourcesError implements Exception {
-  const _NoSourcesError();
-}
 
 /// Per-source probe result for the "check streams" UI.
 /// One row in the subtitles sheet: embedded tracks + online offers for a language.
@@ -75,6 +72,9 @@ class PlayerScreenArgs {
     this.preservedCaption,
     this.preservedExternalOfferId,
     this.preservedExternalSummary,
+    this.isLive = false,
+    this.liveChannelName,
+    this.liveCurrentProgram,
   }) : _initialSourceIndex = initialSourceIndex;
 
   final MediaItem mediaItem;
@@ -108,6 +108,17 @@ class PlayerScreenArgs {
   final StreamCaption? preservedCaption;
   final String? preservedExternalOfferId;
   final String? preservedExternalSummary;
+
+  /// True when this player session is a Live TV channel (native HLS, no
+  /// resume/progress, no XPass injection, no seek). Defaults to false so the
+  /// existing VOD flow is unchanged.
+  final bool isLive;
+
+  /// Channel name shown as the title in the controls overlay for live mode.
+  final String? liveChannelName;
+
+  /// Current EPG program title shown beside the LIVE badge (may be null).
+  final String? liveCurrentProgram;
 
   /// The [OmssSource] the player should open with. Computed once at
   /// construction; the source sheet may swap to a different source by
@@ -260,6 +271,29 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
   /// Guards re-entrant auto-fallback while a fallback reload is in flight.
   bool _autoFallbackInProgress = false;
 
+  /// True once [_activeSource] / [_omssResponse] have been assigned (they are
+  /// `late`). Guards the embed/live getters so they are safe to read before
+  /// playback is wired up (e.g. while sources are still loading or in dispose).
+  bool _sourceInitialized = false;
+
+  /// XPass embed player bridge — position/duration tracked here (no
+  /// [VideoPlayerController] exists in embed mode) and used for progress.
+  final XpassEmbedController _xpassController = XpassEmbedController();
+  double _xpassPosition = 0;
+  double _xpassDuration = 0;
+
+  /// True when the active source is an XPass-style iframe embed. Safe to read
+  /// before [_activeSource] is assigned.
+  bool get _activeSourceIsEmbed =>
+      _sourceInitialized && _activeSource.isEmbed;
+
+  /// True when the embed player is live on screen (controls differ from the
+  /// native video_player path).
+  bool get _isEmbedMode => _playerReady && _activeSourceIsEmbed;
+
+  /// True when this is a Live TV session.
+  bool get _isLive => widget.args.isLive;
+
   void _debugPlayer(String event, [Map<String, Object?> data = const {}]) {
     final Map<String, Object?> fields = <String, Object?>{
       'ready': _playerReady,
@@ -354,6 +388,7 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
   void _initWithResponse(OmssResponse response, OmssSource initial) {
     _omssResponse = response;
     _activeSource = initial;
+    _sourceInitialized = true;
     _activeStreamResult = _synthesizeStreamResult(_omssResponse, _activeSource);
 
     _debugPlayer('init', <String, Object?>{
@@ -382,19 +417,28 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
       if (!mounted) {
         return;
       }
-      if (response.isEmpty) {
-        setState(() {
-          _sourcesLoading = false;
-          _sourcesError = const _NoSourcesError();
-        });
-        return;
-      }
+      // Append the synthetic XPass embed source as a last-resort, lowest
+      // priority option. Because XPass is always present, the response is
+      // never empty here — so a title with zero OMSS sources still plays via
+      // the embed instead of surfacing [_NoSourcesError].
+      final OmssSource xpass = XpassService.buildSource(
+        widget.args.mediaItem,
+        season: widget.args.season,
+        episode: widget.args.episode,
+      );
+      final OmssResponse withXpass = OmssResponse(
+        responseId: response.responseId,
+        expiresAt: response.expiresAt,
+        sources: <OmssSource>[...response.sources, xpass],
+        subtitles: response.subtitles,
+        diagnostics: response.diagnostics,
+      );
       setState(() {
         _sourcesLoading = false;
       });
       _initWithResponse(
-        response,
-        widget.args.initialSourceFrom(response),
+        withXpass,
+        widget.args.initialSourceFrom(withXpass),
       );
       if (mounted) {
         setState(() {});
@@ -505,8 +549,11 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
     WidgetsBinding.instance.removeObserver(this);
     // Capture before subscriptions/player tear-down so async persist does not
     // read mpv state after [Player.dispose] (race that dropped progress).
-    final int snapPos = _position.inSeconds;
-    final int snapDur = _duration.inSeconds;
+    final bool snapEmbed = _isEmbedMode;
+    final int snapPos =
+        snapEmbed ? _xpassPosition.round() : _position.inSeconds;
+    final int snapDur =
+        snapEmbed ? _xpassDuration.round() : _duration.inSeconds;
     final bool snapReady = _playerReady;
     unawaited(
       _persistProgressValues(
@@ -983,6 +1030,24 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     _debugPlayer('lifecycle', <String, Object?>{'state': state.name});
+    // Embed (XPass) playback lives in a WebView; pause/resume it directly
+    // instead of tearing down and re-opening a [VideoPlayerController].
+    if (_isEmbedMode) {
+      switch (state) {
+        case AppLifecycleState.hidden:
+        case AppLifecycleState.paused:
+          _xpassController.pause();
+          unawaited(_persistProgress());
+          break;
+        case AppLifecycleState.resumed:
+          _xpassController.play();
+          break;
+        case AppLifecycleState.inactive:
+        case AppLifecycleState.detached:
+          break;
+      }
+      return;
+    }
     switch (state) {
       // Do not treat [inactive] as background: opening the notification shade,
       // volume HUD, or brief focus loss fires [inactive] then [resumed] without
@@ -1114,6 +1179,28 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
     }
   }
 
+  /// Receives state pushed up from [XpassEmbedPlayer]. Position/duration are
+  /// stored for [_persistProgress]; error/playing changes drive a rebuild.
+  void _onXpassStateChanged(XpassPlayerState state) {
+    if (!mounted) {
+      return;
+    }
+    _xpassPosition = state.position;
+    _xpassDuration = state.duration;
+    if (state.hasError && !_hasPlaybackError) {
+      setState(() {
+        _hasPlaybackError = true;
+        _playbackError = state.errorMessage ?? 'Embed playback failed.';
+      });
+      return;
+    }
+    if (state.isPlaying != _playing) {
+      setState(() {
+        _playing = state.isPlaying;
+      });
+    }
+  }
+
   /// Maps the OMSS-declared stream type to a [VideoFormat] so the platform
   /// player chooses the right media source for extension-less proxy URLs.
   static VideoFormat? _videoFormatHint(StreamPlayback playback) {
@@ -1135,6 +1222,40 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
   }
 
   Future<void> _openStream({int? resumeFrom}) async {
+    // Embed sources (XPass) are rendered in a WebView — there is no
+    // [VideoPlayerController]. Tear down any prior controller, mark ready, and
+    // let [build] render [XpassEmbedPlayer]. Resume is handled inside the embed
+    // widget via its `ready` event.
+    if (_activeSourceIsEmbed) {
+      _videoStallTimer?.cancel();
+      if (resumeFrom != null && resumeFrom > 0) {
+        _resumeFromOverride = resumeFrom;
+      }
+      final VideoPlayerController? old = _controller;
+      if (old != null) {
+        old.removeListener(_onControllerUpdate);
+        await old.dispose();
+      }
+      _controller = null;
+      _xpassPosition = 0;
+      _xpassDuration = 0;
+      if (!mounted) {
+        return;
+      }
+      _debugPlayer('open.embed', _debugSourceFields());
+      setState(() {
+        _openingStream = false;
+        _playerReady = true;
+        _hasPlaybackError = false;
+        _playbackError = null;
+        _buffering = false;
+        _hasFirstVideoFrame = true;
+        _controlsLocked = false;
+        _controlsVisible = true;
+      });
+      return;
+    }
+
     final StreamPlayback playback = _activeStreamResult.stream;
     final String? url = _selectedQualityUrl ?? _resolvePlayableUrl(playback);
     // cinepro sets Referer / Origin / User-Agent server-side on the proxy URL.
@@ -1396,6 +1517,10 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
   }
 
   int? get _resolvedResumeFrom {
+    // Live TV never resumes — there is no stored progress to seek to.
+    if (widget.args.isLive) {
+      return null;
+    }
     if (_resumeFromOverride != null && _resumeFromOverride! > 0) {
       return _resumeFromOverride;
     }
@@ -1488,6 +1613,11 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
     _failedSourceUrls.add(_activeSource.resolvedUrl);
     OmssSource? next;
     for (final OmssSource s in _omssResponse.sources) {
+      // Never auto-fallback into the XPass embed — it is a manual,
+      // last-resort choice from the Sources sheet, not a silent failover.
+      if (s.isEmbed) {
+        continue;
+      }
       if (!_failedSourceUrls.contains(s.resolvedUrl)) {
         next = s;
         break;
@@ -1531,9 +1661,15 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
   }
 
   Future<void> _persistProgress({bool refresh = true}) async {
+    // Embed mode has no [VideoPlayerController]; read position/duration from
+    // the XPass bridge instead.
+    final int positionSecs =
+        _isEmbedMode ? _xpassPosition.round() : _position.inSeconds;
+    final int durationSecs =
+        _isEmbedMode ? _xpassDuration.round() : _duration.inSeconds;
     await _persistProgressValues(
-      positionSecs: _position.inSeconds,
-      durationSecs: _duration.inSeconds,
+      positionSecs: positionSecs,
+      durationSecs: durationSecs,
       playerReady: _playerReady,
       refresh: refresh,
     );
@@ -1548,6 +1684,10 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
     required bool playerReady,
     bool refresh = true,
   }) async {
+    // Live TV keeps no watch history — there is nothing to resume.
+    if (widget.args.isLive) {
+      return;
+    }
     if (!playerReady || positionSecs <= 0) {
       return;
     }
@@ -1695,6 +1835,8 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
                     sourceLabel: _sourceLabelForSettings,
                     subtitleLabel: _currentSubtitleLabel,
                     sourceSwitching: _sourceSwitching,
+                    // Embed (XPass) and Live streams expose no quality variants.
+                    showQuality: !_activeSourceIsEmbed && !_isLive,
                     onQualityTap: () async {
                       await _openQualitySheet();
                       setSheetState(() {});
@@ -1775,6 +1917,9 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
               currentProviderKey: _omssProviderKey(_activeSource),
               refreshing: _refreshingSources,
               switchingProviderKey: _pendingSourceId,
+              // Live channels carry a single source — there is nothing to
+              // refresh.
+              showRefresh: !_isLive,
               onRefreshSources: () {
                 unawaited(_runSourceProbeForCatalog());
               },
@@ -2537,6 +2682,10 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
     if (_controlsLocked || !_playerReady) {
       return;
     }
+    // Live streams cannot be seeked — ignore double-tap skip gestures.
+    if (_isLive) {
+      return;
+    }
     final double width = MediaQuery.sizeOf(context).width;
     if (width <= 0) {
       return;
@@ -3078,11 +3227,58 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
     if (error is SocketException) {
       return "Couldn't reach the resolver. Check your connection.";
     }
-    if (error is _NoSourcesError) {
-      return 'No playable sources for this title right now. '
-          'It may be too new, region-locked, or temporarily unavailable.';
-    }
     return 'Something went wrong while finding sources.';
+  }
+
+  /// Minimal overlay for XPass embed mode: a back button and a source-switch
+  /// button only. The XPass WebView renders its own transport controls, so we
+  /// deliberately omit the progress bar, play/pause, seek, and quality/subtitle
+  /// affordances here.
+  Widget _buildEmbedTopOverlay(BuildContext context, String title) {
+    return SafeArea(
+      child: Align(
+        alignment: Alignment.topCenter,
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.x2),
+          child: Row(
+            children: <Widget>[
+              IconButton(
+                onPressed: _exitPlayer,
+                tooltip: 'Back',
+                constraints: const BoxConstraints.tightFor(
+                  width: 44,
+                  height: 44,
+                ),
+                icon: const Icon(Icons.arrow_back_rounded),
+                color: AppColors.typeEmphasis,
+              ),
+              const SizedBox(width: AppSpacing.x2),
+              Expanded(
+                child: Text(
+                  title,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        color: AppColors.typeEmphasis,
+                      ),
+                ),
+              ),
+              const SizedBox(width: AppSpacing.x2),
+              IconButton(
+                onPressed: () => unawaited(_openSourceSheet()),
+                tooltip: 'Switch source',
+                constraints: const BoxConstraints.tightFor(
+                  width: 44,
+                  height: 44,
+                ),
+                icon: const Icon(Icons.swap_horiz_rounded),
+                color: AppColors.typeEmphasis,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 
   @override
@@ -3092,7 +3288,9 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
     }
 
     final String title;
-    if (widget.args.mediaItem.isShow &&
+    if (_isLive) {
+      title = widget.args.liveChannelName ?? widget.args.mediaItem.title;
+    } else if (widget.args.mediaItem.isShow &&
         widget.args.season != null &&
         widget.args.episode != null) {
       title =
@@ -3101,23 +3299,32 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
       title = widget.args.mediaItem.title;
     }
 
+    // In embed mode the XPass WebView renders its own player UI and handles its
+    // own touches; the outer gesture detector must defer to it so taps/scrolls
+    // reach the embed instead of toggling our (hidden) native controls.
+    final bool embed = _activeSourceIsEmbed;
+
     return PopScope(
       canPop: true,
       child: Scaffold(
         backgroundColor: AppColors.blackC50,
         body: GestureDetector(
-          behavior: HitTestBehavior.opaque,
-          onTap: _handleScreenTap,
-          onDoubleTapDown: _handleDoubleTapDown,
+          behavior: embed
+              ? HitTestBehavior.deferToChild
+              : HitTestBehavior.opaque,
+          onTap: embed ? null : _handleScreenTap,
+          onDoubleTapDown: embed ? null : _handleDoubleTapDown,
           // [onDoubleTap] required so the framework actually waits for a
           // potential second tap before firing onTap (slight delay) instead
           // of dropping our [onDoubleTapDown] handler.
-          onDoubleTap: () {},
-          onVerticalDragStart: _onVerticalDragStart,
-          onVerticalDragUpdate: (DragUpdateDetails details) {
-            unawaited(_onVerticalDragUpdate(details));
-          },
-          onVerticalDragEnd: _onVerticalDragEnd,
+          onDoubleTap: embed ? null : () {},
+          onVerticalDragStart: embed ? null : _onVerticalDragStart,
+          onVerticalDragUpdate: embed
+              ? null
+              : (DragUpdateDetails details) {
+                  unawaited(_onVerticalDragUpdate(details));
+                },
+          onVerticalDragEnd: embed ? null : _onVerticalDragEnd,
           // Backdrop + video fill the entire screen (edge-to-edge, under the
           // display cutout) so playback is truly full-screen. Only the
           // controls/overlays below are wrapped in SafeArea.
@@ -3126,7 +3333,19 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
             children: <Widget>[
               if (!_playerReady)
                 _PlayerBackdrop(mediaItem: widget.args.mediaItem),
-              Positioned.fill(
+              if (embed)
+                Positioned.fill(
+                  child: _playerReady
+                      ? XpassEmbedPlayer(
+                          embedUrl: _activeSource.url,
+                          controller: _xpassController,
+                          resumeFrom: _resolvedResumeFrom,
+                          onStateChanged: _onXpassStateChanged,
+                        )
+                      : const SizedBox.shrink(),
+                )
+              else
+                Positioned.fill(
                   child: IgnorePointer(
                     child: (_playerReady && _controller != null && _controller!.value.isInitialized)
                         ? AnimatedOpacity(
@@ -3280,30 +3499,35 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
                       ),
                     ),
                   ),
-                SafeArea(
-                  child: PlayerControls(
-                  visible: _controlsVisible && !_controlsLocked,
-                  mediaTitle: title,
-                  isPlaying: _playing,
-                  position: _position,
-                  duration: _duration,
-                  buffered: _buffer,
-                  showNextEpisode: _shouldShowNextEpisode,
-                  nextEpisodeLabel: _nextEpisodeTarget?.label,
-                  onBack: _exitPlayer,
-                  onPlayPause: _togglePlayback,
-                  onSeekBack: () => _seekRelative(-10),
-                  onSeekForward: () => _seekRelative(10),
-                  onSeek: _seekToFraction,
-                  onOpenSettings: _openPlayerSettingsSheet,
-                  onOpenBrightness: _openBrightnessSheet,
-                  onOpenVolume: _openVolumeSheet,
-                  autoRotate: !_landscapeLocked,
-                  onToggleAutoRotate: _toggleAutoRotate,
-                  onLock: _lockControls,
-                  onNextEpisode: _playNextEpisode,
+                if (embed)
+                  _buildEmbedTopOverlay(context, title)
+                else
+                  SafeArea(
+                    child: PlayerControls(
+                    visible: _controlsVisible && !_controlsLocked,
+                    mediaTitle: title,
+                    isPlaying: _playing,
+                    position: _position,
+                    duration: _duration,
+                    buffered: _buffer,
+                    isLive: _isLive,
+                    liveProgramTitle: widget.args.liveCurrentProgram,
+                    showNextEpisode: _shouldShowNextEpisode,
+                    nextEpisodeLabel: _nextEpisodeTarget?.label,
+                    onBack: _exitPlayer,
+                    onPlayPause: _togglePlayback,
+                    onSeekBack: () => _seekRelative(-10),
+                    onSeekForward: () => _seekRelative(10),
+                    onSeek: _seekToFraction,
+                    onOpenSettings: _openPlayerSettingsSheet,
+                    onOpenBrightness: _openBrightnessSheet,
+                    onOpenVolume: _openVolumeSheet,
+                    autoRotate: !_landscapeLocked,
+                    onToggleAutoRotate: _toggleAutoRotate,
+                    onLock: _lockControls,
+                    onNextEpisode: _playNextEpisode,
+                    ),
                   ),
-                ),
                 if (_subtitlesEnabled && _currentSubtitleText.isNotEmpty && _playerReady)
                   AnimatedPositioned(
                     duration: const Duration(milliseconds: 200),
@@ -3850,6 +4074,7 @@ class _SourcesCatalogSheet extends StatelessWidget {
     required this.switchingProviderKey,
     required this.onRefreshSources,
     required this.onPickProvider,
+    this.showRefresh = true,
   });
 
   /// Every OMSS source (all provider/quality pairs). Grouped by provider here.
@@ -3859,6 +4084,9 @@ class _SourcesCatalogSheet extends StatelessWidget {
   final String? switchingProviderKey;
   final VoidCallback onRefreshSources;
   final void Function(String providerKey) onPickProvider;
+
+  /// When false the "Refresh sources" footer is hidden (live = one source).
+  final bool showRefresh;
 
   @override
   Widget build(BuildContext context) {
@@ -3893,7 +4121,10 @@ class _SourcesCatalogSheet extends StatelessWidget {
               final List<OmssSource> providerVariants = variants[key]!;
               final bool isCurrent = key == currentProviderKey;
               final bool isSwitching = key == switchingProviderKey;
-              final String qualitySummary = _qualitySummary(providerVariants);
+              // Embed sources have no quality variants — label them plainly.
+              final String qualitySummary = source.isEmbed
+                  ? 'Embed Player'
+                  : _qualitySummary(providerVariants);
               return DecoratedBox(
                 decoration: BoxDecoration(
                   color: isCurrent
@@ -4029,23 +4260,25 @@ class _SourcesCatalogSheet extends StatelessWidget {
               );
             },
           ),
-        const Divider(color: AppColors.utilsDivider, height: AppSpacing.x4),
-        Text(
-          'cinepro returned these providers for this title. Pick one to '
-          'switch — choose a stream quality from the Quality menu. '
-          '"Refresh sources" re-issues the same request in case a previously '
-          'unavailable provider is back.',
-          style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                color: AppColors.typeSecondary,
-              ),
-        ),
-        const SizedBox(height: AppSpacing.x2),
-        TextButton(
-          onPressed: refreshing ? null : onRefreshSources,
-          child: Text(
-            refreshing ? 'Refreshing…' : 'Refresh sources',
+        if (showRefresh) ...<Widget>[
+          const Divider(color: AppColors.utilsDivider, height: AppSpacing.x4),
+          Text(
+            'cinepro returned these providers for this title. Pick one to '
+            'switch — choose a stream quality from the Quality menu. '
+            '"Refresh sources" re-issues the same request in case a previously '
+            'unavailable provider is back.',
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: AppColors.typeSecondary,
+                ),
           ),
-        ),
+          const SizedBox(height: AppSpacing.x2),
+          TextButton(
+            onPressed: refreshing ? null : onRefreshSources,
+            child: Text(
+              refreshing ? 'Refreshing…' : 'Refresh sources',
+            ),
+          ),
+        ],
       ],
       ),
     );
@@ -4139,6 +4372,7 @@ class _PlayerSettingsHomeSheet extends StatelessWidget {
     required this.onQualityTap,
     required this.onSourceTap,
     required this.onSubtitlesTap,
+    this.showQuality = true,
   });
 
   final String qualityLabel;
@@ -4148,6 +4382,10 @@ class _PlayerSettingsHomeSheet extends StatelessWidget {
   final VoidCallback onQualityTap;
   final VoidCallback onSourceTap;
   final VoidCallback onSubtitlesTap;
+
+  /// When false the Quality card is hidden (embed/live have no variants) and
+  /// the Source card spans the full width.
+  final bool showQuality;
 
   @override
   Widget build(BuildContext context) {
@@ -4159,50 +4397,59 @@ class _PlayerSettingsHomeSheet extends StatelessWidget {
         // Row children already fill internally, coming-soon tiles too.
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[
-          // Two cards side-by-side: Quality + Source.
-          LayoutBuilder(
-            builder: (BuildContext context, BoxConstraints constraints) {
-              final bool stackCards = constraints.maxWidth < 360;
-              if (stackCards) {
-                return Column(
+          // Source card, optionally paired with a Quality card (hidden for
+          // embed/live streams which expose no quality variants).
+          if (!showQuality)
+            _PlayerSettingsCard(
+              title: 'Source',
+              subtitle: sourceLabel,
+              loading: sourceSwitching,
+              onTap: onSourceTap,
+            )
+          else
+            LayoutBuilder(
+              builder: (BuildContext context, BoxConstraints constraints) {
+                final bool stackCards = constraints.maxWidth < 360;
+                if (stackCards) {
+                  return Column(
+                    children: <Widget>[
+                      _PlayerSettingsCard(
+                        title: 'Quality',
+                        subtitle: qualityLabel,
+                        onTap: onQualityTap,
+                      ),
+                      SizedBox(height: metrics.itemGap),
+                      _PlayerSettingsCard(
+                        title: 'Source',
+                        subtitle: sourceLabel,
+                        loading: sourceSwitching,
+                        onTap: onSourceTap,
+                      ),
+                    ],
+                  );
+                }
+                return Row(
                   children: <Widget>[
-                    _PlayerSettingsCard(
-                      title: 'Quality',
-                      subtitle: qualityLabel,
-                      onTap: onQualityTap,
+                    Expanded(
+                      child: _PlayerSettingsCard(
+                        title: 'Quality',
+                        subtitle: qualityLabel,
+                        onTap: onQualityTap,
+                      ),
                     ),
-                    SizedBox(height: metrics.itemGap),
-                    _PlayerSettingsCard(
-                      title: 'Source',
-                      subtitle: sourceLabel,
-                      loading: sourceSwitching,
-                      onTap: onSourceTap,
+                    SizedBox(width: metrics.itemGap),
+                    Expanded(
+                      child: _PlayerSettingsCard(
+                        title: 'Source',
+                        subtitle: sourceLabel,
+                        loading: sourceSwitching,
+                        onTap: onSourceTap,
+                      ),
                     ),
                   ],
                 );
-              }
-              return Row(
-                children: <Widget>[
-                  Expanded(
-                    child: _PlayerSettingsCard(
-                      title: 'Quality',
-                      subtitle: qualityLabel,
-                      onTap: onQualityTap,
-                    ),
-                  ),
-                  SizedBox(width: metrics.itemGap),
-                  Expanded(
-                    child: _PlayerSettingsCard(
-                      title: 'Source',
-                      subtitle: sourceLabel,
-                      loading: sourceSwitching,
-                      onTap: onSourceTap,
-                    ),
-                  ),
-                ],
-              );
-            },
-          ),
+              },
+            ),
           SizedBox(height: metrics.itemGap),
           // Subtitles spans full width — replaces the old 2x2 layout that
           // also held a non-clickable "Audio" tile (always HLS).

--- a/lib/services/live_service.dart
+++ b/lib/services/live_service.dart
@@ -1,0 +1,106 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+import 'package:pstream_android/models/live_channel.dart';
+
+/// Fetches Live TV channels + EPG from the public `wfs.lol` endpoints.
+///
+/// Uses the existing `http` package and an in-memory cache shared across
+/// instances (channels: 24h TTL, EPG: 1h TTL) so tab switches and rebuilds do
+/// not re-hit the network. No new dependencies.
+class LiveService {
+  const LiveService();
+
+  static const String _channelsUrl = 'https://wfs.lol/live-channels.json';
+  static const String _epgUrl = 'https://wfs.lol/live-epg.json';
+
+  static const Map<String, String> _headers = <String, String>{
+    'Accept': 'application/json',
+  };
+
+  static const Duration _timeout = Duration(seconds: 20);
+  static const Duration _channelsTtl = Duration(hours: 24);
+  static const Duration _epgTtl = Duration(hours: 1);
+
+  static List<LiveChannel>? _channelsCache;
+  static DateTime? _channelsFetchedAt;
+  static Map<String, List<LiveProgram>>? _epgCache;
+  static DateTime? _epgFetchedAt;
+
+  Future<List<LiveChannel>> fetchChannels() async {
+    final List<LiveChannel>? cached = _channelsCache;
+    final DateTime? at = _channelsFetchedAt;
+    if (cached != null &&
+        at != null &&
+        DateTime.now().difference(at) < _channelsTtl) {
+      return cached;
+    }
+
+    final dynamic decoded = await _getJson(_channelsUrl);
+    if (decoded is! List) {
+      throw const FormatException('live-channels.json is not a JSON array.');
+    }
+
+    final List<LiveChannel> channels = decoded
+        .whereType<Map>()
+        .map((Map e) => LiveChannel.fromJson(Map<String, dynamic>.from(e)))
+        .where((LiveChannel c) => c.url.isNotEmpty && c.name.isNotEmpty)
+        .toList(growable: false);
+
+    _channelsCache = channels;
+    _channelsFetchedAt = DateTime.now();
+    return channels;
+  }
+
+  Future<Map<String, List<LiveProgram>>> fetchEpg() async {
+    final Map<String, List<LiveProgram>>? cached = _epgCache;
+    final DateTime? at = _epgFetchedAt;
+    if (cached != null &&
+        at != null &&
+        DateTime.now().difference(at) < _epgTtl) {
+      return cached;
+    }
+
+    final dynamic decoded = await _getJson(_epgUrl);
+    if (decoded is! Map) {
+      throw const FormatException('live-epg.json is not a JSON object.');
+    }
+
+    final Map<String, List<LiveProgram>> epg = <String, List<LiveProgram>>{};
+    decoded.forEach((dynamic key, dynamic value) {
+      if (value is! List) {
+        return;
+      }
+      final List<LiveProgram> programs = value
+          .whereType<Map>()
+          .map(
+            (Map e) => LiveProgram.fromJson(Map<String, dynamic>.from(e)),
+          )
+          .toList(growable: false);
+      epg['$key'.toLowerCase()] = programs;
+    });
+
+    _epgCache = epg;
+    _epgFetchedAt = DateTime.now();
+    return epg;
+  }
+
+  Future<dynamic> _getJson(String url) async {
+    final http.Client client = http.Client();
+    try {
+      final http.Response response =
+          await client.get(Uri.parse(url), headers: _headers).timeout(_timeout);
+      if (response.statusCode != 200) {
+        throw HttpException(
+          'HTTP ${response.statusCode} from $url',
+          uri: Uri.parse(url),
+        );
+      }
+      return jsonDecode(response.body);
+    } finally {
+      client.close();
+    }
+  }
+}

--- a/lib/services/xpass_service.dart
+++ b/lib/services/xpass_service.dart
@@ -1,0 +1,34 @@
+import 'package:pstream_android/models/media_item.dart';
+import 'package:pstream_android/models/omss_source.dart';
+
+/// Builds the synthetic [OmssSource] for the XPass iframe embed player.
+///
+/// `play.xpass.top` is an iframe embed player (loaded in a WebView), not a raw
+/// stream URL. These helpers are pure and stateless — no HTTP, no extra deps.
+class XpassService {
+  XpassService._();
+
+  static const String _base = 'https://play.xpass.top';
+  static const String _providerId = 'xpass';
+  static const String _providerName = 'XPass';
+
+  static String buildMovieEmbedUrl(String tmdbId) => '$_base/e/movie/$tmdbId';
+
+  static String buildTvEmbedUrl(String tmdbId, int season, int episode) =>
+      '$_base/e/tv/$tmdbId/$season/$episode';
+
+  /// Builds the synthetic [OmssSource] to inject into any [OmssResponse].
+  static OmssSource buildSource(MediaItem item, {int? season, int? episode}) {
+    final String tmdbId = '${item.tmdbId}';
+    final String url = (season != null && episode != null)
+        ? buildTvEmbedUrl(tmdbId, season, episode)
+        : buildMovieEmbedUrl(tmdbId);
+    return OmssSource(
+      url: url,
+      type: 'embed',
+      quality: null,
+      providerId: _providerId,
+      providerName: _providerName,
+    );
+  }
+}

--- a/lib/widgets/adaptive_nav.dart
+++ b/lib/widgets/adaptive_nav.dart
@@ -32,6 +32,11 @@ class AdaptiveNav extends StatelessWidget {
       selectedIcon: Icons.bookmark_rounded,
     ),
     _AdaptiveNavDestination(
+      label: 'Live TV',
+      icon: Icons.live_tv_outlined,
+      selectedIcon: Icons.live_tv_rounded,
+    ),
+    _AdaptiveNavDestination(
       label: 'Settings',
       icon: Icons.settings_outlined,
       selectedIcon: Icons.settings_rounded,

--- a/lib/widgets/channel_card.dart
+++ b/lib/widgets/channel_card.dart
@@ -1,0 +1,222 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:pstream_android/config/app_theme.dart';
+import 'package:pstream_android/models/live_channel.dart';
+
+/// Grid tile for a single Live TV channel.
+///
+/// Shows the channel logo, a category chip, the channel name, and — when EPG
+/// data is available — a `● LIVE` badge with the current program title.
+class ChannelCard extends StatelessWidget {
+  const ChannelCard({
+    super.key,
+    required this.channel,
+    required this.onTap,
+    this.currentProgram,
+  });
+
+  final LiveChannel channel;
+  final VoidCallback onTap;
+
+  /// Current EPG program title; null when no EPG data is available.
+  final String? currentProgram;
+
+  @override
+  Widget build(BuildContext context) {
+    return RepaintBoundary(
+      child: Material(
+        color: AppColors.glassSheet,
+        borderRadius: BorderRadius.circular(AppSpacing.x4),
+        clipBehavior: Clip.antiAlias,
+        child: InkWell(
+          onTap: onTap,
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(AppSpacing.x4),
+              border: Border.all(color: AppColors.glassBorder),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: <Widget>[
+                Expanded(
+                  child: Stack(
+                    children: <Widget>[
+                      Positioned.fill(
+                        child: Padding(
+                          padding: const EdgeInsets.all(AppSpacing.x4),
+                          child: _ChannelLogo(channel: channel),
+                        ),
+                      ),
+                      Positioned(
+                        left: AppSpacing.x2,
+                        bottom: AppSpacing.x2,
+                        child: _CategoryChip(category: channel.cat),
+                      ),
+                    ],
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(
+                    AppSpacing.x3,
+                    AppSpacing.x2,
+                    AppSpacing.x3,
+                    AppSpacing.x3,
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: <Widget>[
+                      Text(
+                        channel.name,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                              color: AppColors.typeEmphasis,
+                            ),
+                      ),
+                      if (currentProgram != null &&
+                          currentProgram!.isNotEmpty) ...<Widget>[
+                        const SizedBox(height: AppSpacing.x1),
+                        Row(
+                          children: <Widget>[
+                            Container(
+                              width: AppSpacing.x2,
+                              height: AppSpacing.x2,
+                              decoration: const BoxDecoration(
+                                shape: BoxShape.circle,
+                                color: AppColors.semanticRedC200,
+                              ),
+                            ),
+                            const SizedBox(width: AppSpacing.x1),
+                            Expanded(
+                              child: Text(
+                                currentProgram!,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .labelSmall
+                                    ?.copyWith(color: AppColors.typeSecondary),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ChannelLogo extends StatelessWidget {
+  const _ChannelLogo({required this.channel});
+
+  final LiveChannel channel;
+
+  @override
+  Widget build(BuildContext context) {
+    if (channel.logo.isEmpty) {
+      return _LogoFallback(channel: channel);
+    }
+    return CachedNetworkImage(
+      imageUrl: channel.logo,
+      fit: BoxFit.contain,
+      placeholder: (BuildContext context, String url) =>
+          const SizedBox.shrink(),
+      errorWidget: (BuildContext context, String url, Object error) =>
+          _LogoFallback(channel: channel),
+    );
+  }
+}
+
+class _LogoFallback extends StatelessWidget {
+  const _LogoFallback({required this.channel});
+
+  final LiveChannel channel;
+
+  @override
+  Widget build(BuildContext context) {
+    final String initial =
+        channel.name.isNotEmpty ? channel.name.characters.first.toUpperCase() : '?';
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          const Icon(
+            Icons.live_tv_rounded,
+            color: AppColors.typeSecondary,
+            size: AppSpacing.x10,
+          ),
+          const SizedBox(height: AppSpacing.x1),
+          Text(
+            initial,
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  color: AppColors.typeEmphasis,
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CategoryChip extends StatelessWidget {
+  const _CategoryChip({required this.category});
+
+  final String category;
+
+  @override
+  Widget build(BuildContext context) {
+    if (category.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    final Color color = _categoryColor(category);
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: AppColors.blackC50.withValues(alpha: 0.62),
+        borderRadius: BorderRadius.circular(AppSpacing.x4),
+        border: Border.all(color: color.withValues(alpha: 0.8)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.x2,
+          vertical: AppSpacing.x1,
+        ),
+        child: Text(
+          category,
+          style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                color: color,
+                fontWeight: FontWeight.w700,
+              ),
+        ),
+      ),
+    );
+  }
+
+  static Color _categoryColor(String category) {
+    switch (category.toLowerCase()) {
+      case 'sports':
+        return AppColors.purpleC200;
+      case 'news':
+        return AppColors.semanticRedC200;
+      case 'entertainment':
+        return AppColors.semanticYellowC200;
+      case 'kids':
+        return AppColors.semanticGreenC100;
+      case 'movies':
+        return AppColors.blueC200;
+      case 'music':
+        return AppColors.semanticRoseC100;
+      case 'docs':
+        return AppColors.semanticSilverC300;
+      default:
+        return AppColors.typeSecondary;
+    }
+  }
+}

--- a/lib/widgets/player_controls.dart
+++ b/lib/widgets/player_controls.dart
@@ -28,6 +28,8 @@ class PlayerControls extends StatelessWidget {
     required this.onLock,
     required this.onNextEpisode,
     this.nextEpisodeLabel,
+    this.isLive = false,
+    this.liveProgramTitle,
   });
 
   final bool visible;
@@ -37,6 +39,14 @@ class PlayerControls extends StatelessWidget {
   final Duration duration;
   final Duration buffered;
   final bool showNextEpisode;
+
+  /// When true the seek bar + timecodes are replaced with a `● LIVE` badge
+  /// row (live HLS streams cannot be scrubbed). Defaults to false so the VOD
+  /// controls are unchanged.
+  final bool isLive;
+
+  /// Current EPG program title shown beside the LIVE badge (may be null).
+  final String? liveProgramTitle;
   final VoidCallback onBack;
   final Future<void> Function() onPlayPause;
   final Future<void> Function() onSeekBack;
@@ -177,27 +187,75 @@ class PlayerControls extends StatelessWidget {
                       padding: metrics.barPadding,
                       child: Column(
                         children: <Widget>[
-                          _SeekBar(
-                            position: position,
-                            duration: duration,
-                            buffered: buffered,
-                            onSeek: onSeek,
-                          ),
-                          SizedBox(height: metrics.compactGap),
+                          if (!isLive) ...<Widget>[
+                            _SeekBar(
+                              position: position,
+                              duration: duration,
+                              buffered: buffered,
+                              onSeek: onSeek,
+                            ),
+                            SizedBox(height: metrics.compactGap),
+                          ],
                           Row(
                             children: <Widget>[
-                              Text(
-                                _formatDuration(position),
-                                style: Theme.of(context).textTheme.labelMedium
-                                    ?.copyWith(fontSize: metrics.timeTextSize),
-                              ),
-                              SizedBox(width: metrics.compactGap),
-                              Text(
-                                '/ ${_formatDuration(duration)}',
-                                style: Theme.of(context).textTheme.labelMedium
-                                    ?.copyWith(fontSize: metrics.timeTextSize),
-                              ),
-                              const Spacer(),
+                              if (isLive) ...<Widget>[
+                                Container(
+                                  width: AppSpacing.x2,
+                                  height: AppSpacing.x2,
+                                  decoration: const BoxDecoration(
+                                    shape: BoxShape.circle,
+                                    color: AppColors.semanticRedC200,
+                                  ),
+                                ),
+                                SizedBox(width: metrics.compactGap),
+                                Text(
+                                  'LIVE',
+                                  style: Theme.of(context)
+                                      .textTheme
+                                      .labelMedium
+                                      ?.copyWith(
+                                        fontSize: metrics.timeTextSize,
+                                        color: AppColors.semanticRedC200,
+                                        fontWeight: FontWeight.w700,
+                                      ),
+                                ),
+                                if (liveProgramTitle != null &&
+                                    liveProgramTitle!.isNotEmpty)
+                                  Expanded(
+                                    child: Padding(
+                                      padding: const EdgeInsets.only(
+                                        left: AppSpacing.x3,
+                                        right: AppSpacing.x2,
+                                      ),
+                                      child: Text(
+                                        liveProgramTitle!,
+                                        maxLines: 1,
+                                        overflow: TextOverflow.ellipsis,
+                                        style: Theme.of(context)
+                                            .textTheme
+                                            .labelMedium
+                                            ?.copyWith(
+                                              fontSize: metrics.timeTextSize,
+                                            ),
+                                      ),
+                                    ),
+                                  )
+                                else
+                                  const Spacer(),
+                              ] else ...<Widget>[
+                                Text(
+                                  _formatDuration(position),
+                                  style: Theme.of(context).textTheme.labelMedium
+                                      ?.copyWith(fontSize: metrics.timeTextSize),
+                                ),
+                                SizedBox(width: metrics.compactGap),
+                                Text(
+                                  '/ ${_formatDuration(duration)}',
+                                  style: Theme.of(context).textTheme.labelMedium
+                                      ?.copyWith(fontSize: metrics.timeTextSize),
+                                ),
+                                const Spacer(),
+                              ],
                               IconButton(
                                 onPressed: () {
                                   unawaited(onOpenBrightness());

--- a/lib/widgets/xpass_embed_player.dart
+++ b/lib/widgets/xpass_embed_player.dart
@@ -1,0 +1,263 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+
+import '../config/app_theme.dart';
+
+/// Immutable snapshot of the XPass embed player state, pushed upward to the
+/// host [PlayerScreen] via [XpassEmbedPlayer.onStateChanged].
+class XpassPlayerState {
+  const XpassPlayerState({
+    this.position = 0,
+    this.duration = 0,
+    this.isPlaying = false,
+    this.hasError = false,
+    this.errorMessage,
+  });
+
+  /// Current playback position in seconds.
+  final double position;
+
+  /// Total duration in seconds (0 when unknown).
+  final double duration;
+
+  final bool isPlaying;
+  final bool hasError;
+  final String? errorMessage;
+
+  XpassPlayerState copyWith({
+    double? position,
+    double? duration,
+    bool? isPlaying,
+    bool? hasError,
+    String? errorMessage,
+  }) {
+    return XpassPlayerState(
+      position: position ?? this.position,
+      duration: duration ?? this.duration,
+      isPlaying: isPlaying ?? this.isPlaying,
+      hasError: hasError ?? this.hasError,
+      errorMessage: errorMessage ?? this.errorMessage,
+    );
+  }
+}
+
+/// Imperative handle the host screen uses to drive the embed player.
+///
+/// Bound to the live [XpassEmbedPlayer] state once the widget mounts; calls
+/// before that are safely ignored.
+class XpassEmbedController {
+  _XpassEmbedPlayerState? _state;
+
+  void _attach(_XpassEmbedPlayerState state) => _state = state;
+  void _detach(_XpassEmbedPlayerState state) {
+    if (identical(_state, state)) {
+      _state = null;
+    }
+  }
+
+  void play() => _state?._play();
+  void pause() => _state?._pause();
+  void seek(int seconds) => _state?._seek(seconds);
+}
+
+/// Renders the `play.xpass.top` iframe embed inside an [InAppWebView] and
+/// bridges its `window.postMessage` protocol to/from Flutter.
+class XpassEmbedPlayer extends StatefulWidget {
+  const XpassEmbedPlayer({
+    super.key,
+    required this.embedUrl,
+    required this.onStateChanged,
+    this.controller,
+    this.resumeFrom,
+  });
+
+  final String embedUrl;
+  final ValueChanged<XpassPlayerState> onStateChanged;
+  final XpassEmbedController? controller;
+
+  /// Seconds to resume from — sent as a `playAt` action on the `ready` event.
+  final int? resumeFrom;
+
+  @override
+  State<XpassEmbedPlayer> createState() => _XpassEmbedPlayerState();
+}
+
+class _XpassEmbedPlayerState extends State<XpassEmbedPlayer> {
+  static const String _listenerJs = '''
+window.addEventListener('message', function(e) {
+  try {
+    if (e.data && e.data.type === 'player.event') {
+      window.flutter_inappwebview.callHandler('xpassEvent', JSON.stringify(e.data));
+    }
+  } catch (err) {}
+});
+''';
+
+  InAppWebViewController? _webController;
+  XpassPlayerState _state = const XpassPlayerState();
+
+  @override
+  void initState() {
+    super.initState();
+    widget.controller?._attach(this);
+  }
+
+  @override
+  void didUpdateWidget(covariant XpassEmbedPlayer oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!identical(oldWidget.controller, widget.controller)) {
+      oldWidget.controller?._detach(this);
+      widget.controller?._attach(this);
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.controller?._detach(this);
+    super.dispose();
+  }
+
+  void _emit(XpassPlayerState next) {
+    _state = next;
+    widget.onStateChanged(next);
+  }
+
+  void _postAction(Map<String, Object?> action) {
+    final String payload = jsonEncode(action);
+    _webController?.evaluateJavascript(
+      source: "window.postMessage($payload, '*');",
+    );
+  }
+
+  void _play() => _postAction(<String, Object?>{
+    'type': 'player.action',
+    'action': 'play',
+  });
+
+  void _pause() => _postAction(<String, Object?>{
+    'type': 'player.action',
+    'action': 'pause',
+  });
+
+  void _seek(int seconds) => _postAction(<String, Object?>{
+    'type': 'player.action',
+    'action': 'seek',
+    'position': seconds,
+  });
+
+  void _playAt(int seconds) => _postAction(<String, Object?>{
+    'type': 'player.action',
+    'action': 'playAt',
+    'position': seconds,
+  });
+
+  void _handleEvent(List<dynamic> args) {
+    if (args.isEmpty) {
+      return;
+    }
+    Map<String, dynamic>? data;
+    try {
+      data = jsonDecode('${args.first}') as Map<String, dynamic>;
+    } catch (_) {
+      return;
+    }
+
+    final Object? rawEvent = data['event'];
+    if (rawEvent is! Map) {
+      return;
+    }
+    final Map<String, dynamic> event = Map<String, dynamic>.from(rawEvent);
+    final String name = '${event['name'] ?? ''}';
+
+    switch (name) {
+      case 'ready':
+        final int? resume = widget.resumeFrom;
+        if (resume != null && resume > 0) {
+          _playAt(resume);
+        }
+        break;
+      case 'position':
+        _emit(
+          _state.copyWith(
+            position: _toDouble(event['position']) ?? _state.position,
+            duration: _toDouble(event['duration']) ?? _state.duration,
+          ),
+        );
+        break;
+      case 'play':
+        _emit(_state.copyWith(isPlaying: true));
+        break;
+      case 'pause':
+        _emit(_state.copyWith(isPlaying: false));
+        break;
+      case 'end':
+        _emit(_state.copyWith(isPlaying: false));
+        break;
+      case 'error':
+        _emit(
+          _state.copyWith(
+            hasError: true,
+            errorMessage: '${event['message'] ?? event['code'] ?? 'Embed error'}',
+            isPlaying: false,
+          ),
+        );
+        break;
+      default:
+        break;
+    }
+  }
+
+  static double? _toDouble(Object? value) {
+    if (value is num) {
+      return value.toDouble();
+    }
+    return double.tryParse('$value');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ColoredBox(
+      color: AppColors.blackC50,
+      child: InAppWebView(
+        initialUrlRequest: URLRequest(url: WebUri(widget.embedUrl)),
+        initialSettings: InAppWebViewSettings(
+          transparentBackground: true,
+          mediaPlaybackRequiresUserGesture: false,
+          allowsInlineMediaPlayback: true,
+          javaScriptEnabled: true,
+          supportZoom: false,
+        ),
+        onWebViewCreated: (InAppWebViewController controller) {
+          _webController = controller;
+          controller.addJavaScriptHandler(
+            handlerName: 'xpassEvent',
+            callback: (List<dynamic> args) {
+              _handleEvent(args);
+              return null;
+            },
+          );
+        },
+        onLoadStop: (InAppWebViewController controller, WebUri? url) async {
+          await controller.evaluateJavascript(source: _listenerJs);
+        },
+        onReceivedError: (
+          InAppWebViewController controller,
+          WebResourceRequest request,
+          WebResourceError error,
+        ) {
+          if (request.isForMainFrame ?? false) {
+            _emit(
+              _state.copyWith(
+                hasError: true,
+                errorMessage: error.description,
+                isPlaying: false,
+              ),
+            );
+          }
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Inject XPass as a fallback embed provider in the player, add Live TV browse with EPG-aware channel grid, and wire a fifth nav tab without changing the existing OMSS VOD flow.