### PR TITLE
Add GitHub-backed in-app APK updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,26 @@ jobs:
             exit 1
           fi
 
+      - name: Decode release keystore
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          if [ -z "$ANDROID_KEYSTORE_BASE64" ] || [ -z "$ANDROID_KEYSTORE_PASSWORD" ] || [ -z "$ANDROID_KEY_ALIAS" ] || [ -z "$ANDROID_KEY_PASSWORD" ]; then
+            echo "::error::Release signing secrets are missing. Required: ANDROID_KEYSTORE_BASE64, ANDROID_KEYSTORE_PASSWORD, ANDROID_KEY_ALIAS, ANDROID_KEY_PASSWORD."
+            echo "Without a stable upload keystore, in-app updates cannot install on top of previous APKs."
+            exit 1
+          fi
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 -d > android/upload-keystore.jks
+          printf '%s\n' \
+            "storePassword=$ANDROID_KEYSTORE_PASSWORD" \
+            "keyPassword=$ANDROID_KEY_PASSWORD" \
+            "keyAlias=$ANDROID_KEY_ALIAS" \
+            "storeFile=../upload-keystore.jks" \
+            > android/key.properties
+
       - name: Analyze
         run: flutter analyze
 
@@ -97,13 +117,72 @@ jobs:
 
           flutter "${BUILD_ARGS[@]}"
 
-      - name: Rename APK artifact
-        run: cp build/app/outputs/flutter-apk/app-release.apk build/app/outputs/flutter-apk/veil.apk
+      - name: Prepare release artifacts
+        id: artifacts
+        run: |
+          VERSION_LINE=$(grep '^version:' pubspec.yaml | head -n1 | awk '{print $2}')
+          VERSION_NAME="${VERSION_LINE%%+*}"
+          VERSION_CODE="${VERSION_LINE##*+}"
+          TAG_NAME="${RELEASE_TAG}"
+          if [[ "$TAG_NAME" != v* ]]; then
+            TAG_NAME="v${VERSION_NAME}"
+          fi
+
+          mkdir -p dist
+          cp build/app/outputs/flutter-apk/app-release.apk dist/veil.apk
+          cp build/app/outputs/flutter-apk/app-release.apk "dist/veil-${TAG_NAME}.apk"
+          SHA256=$(sha256sum dist/veil.apk | awk '{print $1}')
+          RELEASED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+          VERSION_NAME="$VERSION_NAME" \
+          VERSION_CODE="$VERSION_CODE" \
+          TAG_NAME="$TAG_NAME" \
+          SHA256="$SHA256" \
+          RELEASED_AT="$RELEASED_AT" \
+          GITHUB_REPOSITORY="${{ github.repository }}" \
+          python3 - <<'PY'
+          import json, os
+          payload = {
+            "versionName": os.environ["VERSION_NAME"],
+            "versionCode": int(os.environ["VERSION_CODE"]),
+            "tag": os.environ["TAG_NAME"],
+            "apkUrl": (
+              f"https://github.com/{os.environ['GITHUB_REPOSITORY']}"
+              f"/releases/download/{os.environ['TAG_NAME']}/veil.apk"
+            ),
+            "sha256": os.environ["SHA256"],
+            "mandatory": False,
+            "minVersionCode": 1,
+            "releasedAt": os.environ["RELEASED_AT"],
+          }
+          with open("dist/version.json", "w", encoding="utf-8") as handle:
+              json.dump(payload, handle, indent=2)
+              handle.write("\n")
+          PY
+
+          {
+            echo "version_name=$VERSION_NAME"
+            echo "version_code=$VERSION_CODE"
+            echo "tag_name=$TAG_NAME"
+            echo "sha256=$SHA256"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ env.RELEASE_TAG }}
-          name: ${{ env.RELEASE_TAG }}
+          tag_name: ${{ steps.artifacts.outputs.tag_name }}
+          name: Veil ${{ steps.artifacts.outputs.version_name }}
+          generate_release_notes: true
           prerelease: false
-          files: build/app/outputs/flutter-apk/veil.apk
+          body: |
+            ## Veil ${{ steps.artifacts.outputs.version_name }}
+
+            - **versionCode:** `${{ steps.artifacts.outputs.version_code }}`
+            - **APK SHA-256:** `${{ steps.artifacts.outputs.sha256 }}`
+
+            Install over any previous release signed with the same upload keystore.
+            Builds that include in-app updates will detect this release automatically via `version.json`.
+          files: |
+            dist/veil.apk
+            dist/veil-${{ steps.artifacts.outputs.tag_name }}.apk
+            dist/version.json

--- a/README.md
+++ b/README.md
@@ -164,7 +164,27 @@ flutter build apk --release \
   --dart-define=TMDB_TOKEN=YOUR_TMDB_READ_TOKEN
 ```
 
-**CI / releases:** pushing a `v*` tag (or manual workflow dispatch) runs `flutter analyze` and builds `veil.apk`. Configure **`ORACLE_URL`** and **`TMDB_TOKEN`** (or **`TMDB_READ_TOKEN`**) as GitHub variables or secrets — the workflow fails fast if either is missing.
+**CI / releases:** pushing a `v*` tag (or manual **Release** workflow dispatch) runs `flutter analyze`, builds a **signed** `veil.apk`, and publishes a GitHub Release with `version.json` (for in-app updates).
+
+Required repository secrets for signed releases:
+
+| Secret | Purpose |
+|--------|---------|
+| `ORACLE_URL` (or variable) | Resolver base URL baked into the APK |
+| `TMDB_TOKEN` or `TMDB_READ_TOKEN` | TMDB read token |
+| `ANDROID_KEYSTORE_BASE64` | Base64-encoded `.jks` / `.keystore` |
+| `ANDROID_KEYSTORE_PASSWORD` | Keystore password |
+| `ANDROID_KEY_ALIAS` | Key alias |
+| `ANDROID_KEY_PASSWORD` | Key password |
+
+**In-app updates:** Settings → **App** → **Check for updates** polls `dikshadamahe/veil-android` GitHub Releases. Newer APKs install on top of older ones when they share the same `applicationId` and signing certificate and the new `versionCode` is higher. Bump `version:` in `pubspec.yaml` (e.g. `1.0.3+4`) before each tagged release.
+
+Generate a one-time upload keystore (do not commit it):
+
+```bash
+keytool -genkey -v -keystore upload-keystore.jks -keyalg RSA -keysize 2048 -validity 10000 -alias upload
+base64 -w0 upload-keystore.jks   # paste into ANDROID_KEYSTORE_BASE64
+```
 
 <details>
 <summary><strong>Optional defines</strong> — subtitles, watch rules</summary>
@@ -186,7 +206,7 @@ flutter build apk --release \
 | Path | Role |
 |------|------|
 | `lib/screens/` | Home, search, detail, player, settings, history, my list |
-| `lib/services/` | `tmdb_service.dart`, `stream_service.dart` (OMSS client) |
+| `lib/services/` | `tmdb_service.dart`, `stream_service.dart` (OMSS client), `app_update_service.dart` |
 | `lib/models/` | `media_item.dart`, `omss_source.dart`, `omss_response.dart` |
 | `lib/config/` | `app_config.dart`, `app_theme.dart`, `router.dart`, breakpoints |
 | `lib/storage/` | Hive — progress, bookmarks, continue watching |

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,8 +1,17 @@
+import java.util.Properties
+import java.io.FileInputStream
+
 plugins {
     id("com.android.application")
     id("kotlin-android")
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
+}
+
+val keystoreProperties = Properties()
+val keystorePropertiesFile = rootProject.file("key.properties")
+if (keystorePropertiesFile.exists()) {
+    keystoreProperties.load(FileInputStream(keystorePropertiesFile))
 }
 
 android {
@@ -30,11 +39,27 @@ android {
         versionName = flutter.versionName
     }
 
+    signingConfigs {
+        create("release") {
+            if (keystorePropertiesFile.exists()) {
+                keyAlias = keystoreProperties["keyAlias"] as String
+                keyPassword = keystoreProperties["keyPassword"] as String
+                storeFile = file(keystoreProperties["storeFile"] as String)
+                storePassword = keystoreProperties["storePassword"] as String
+            }
+        }
+    }
+
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.getByName("debug")
+            // Prefer the release keystore when present so GitHub-published APKs
+            // can install on top of each other. Fall back to debug signing for
+            // local `flutter run --release` without key.properties.
+            signingConfig = if (keystorePropertiesFile.exists()) {
+                signingConfigs.getByName("release")
+            } else {
+                signingConfigs.getByName("debug")
+            }
         }
     }
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
     <application
         android:label="Veil"

--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -104,6 +104,27 @@ class AppConfig {
     return double.tryParse(rawValue) ?? 0.90;
   }
 
+  /// Optional direct URL to a `version.json` manifest. When empty, the app
+  /// falls back to the GitHub Releases API for [updateGithubOwner]/[updateGithubRepo].
+  static String? get updateManifestUrl {
+    const String raw = String.fromEnvironment(
+      'UPDATE_MANIFEST_URL',
+      defaultValue: '',
+    );
+    final String trimmed = raw.trim();
+    return trimmed.isEmpty ? null : trimmed;
+  }
+
+  static String get updateGithubOwner => const String.fromEnvironment(
+        'UPDATE_GITHUB_OWNER',
+        defaultValue: 'dikshadamahe',
+      );
+
+  static String get updateGithubRepo => const String.fromEnvironment(
+        'UPDATE_GITHUB_REPO',
+        defaultValue: 'veil-android',
+      );
+
   static String _trimTrailingSlash(String value) {
     return value.replaceFirst(RegExp(r'/+$'), '');
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,11 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:pstream_android/config/app_theme.dart';
 import 'package:pstream_android/config/router.dart';
+import 'package:pstream_android/providers/app_update_provider.dart';
 import 'package:pstream_android/providers/storage_provider.dart';
 import 'package:pstream_android/providers/tmdb_provider.dart';
 import 'package:pstream_android/storage/local_storage.dart';
@@ -26,6 +29,11 @@ class _VeilAppState extends ConsumerState<VeilApp> with WidgetsBindingObserver {
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      unawaited(
+        ref.read(appUpdateControllerProvider.notifier).checkOnLaunch(),
+      );
+    });
   }
 
   @override

--- a/lib/models/app_update_info.dart
+++ b/lib/models/app_update_info.dart
@@ -1,0 +1,89 @@
+/// Metadata for a published Veil APK release (GitHub Releases / version.json).
+class AppUpdateInfo {
+  const AppUpdateInfo({
+    required this.versionName,
+    required this.versionCode,
+    required this.apkUrl,
+    required this.tag,
+    this.sha256,
+    this.notes,
+    this.mandatory = false,
+    this.minVersionCode = 1,
+  });
+
+  final String versionName;
+  final int versionCode;
+  final String apkUrl;
+  final String tag;
+  final String? sha256;
+  final String? notes;
+  final bool mandatory;
+  final int minVersionCode;
+
+  bool isNewerThan(int installedVersionCode) =>
+      versionCode > installedVersionCode;
+
+  factory AppUpdateInfo.fromJson(Map<String, dynamic> json) {
+    final Object? versionCodeRaw = json['versionCode'] ?? json['version_code'];
+    final int versionCode = switch (versionCodeRaw) {
+      int value => value,
+      String value => int.tryParse(value.trim()) ?? 0,
+      num value => value.toInt(),
+      _ => 0,
+    };
+
+    final Object? minRaw = json['minVersionCode'] ?? json['min_version_code'];
+    final int minVersionCode = switch (minRaw) {
+      int value => value,
+      String value => int.tryParse(value.trim()) ?? 1,
+      num value => value.toInt(),
+      _ => 1,
+    };
+
+    return AppUpdateInfo(
+      versionName: (json['versionName'] ?? json['version_name'] ?? '').toString(),
+      versionCode: versionCode,
+      apkUrl: (json['apkUrl'] ?? json['apk_url'] ?? '').toString(),
+      tag: (json['tag'] ?? '').toString(),
+      sha256: json['sha256']?.toString(),
+      notes: json['notes']?.toString() ?? json['body']?.toString(),
+      mandatory: json['mandatory'] == true,
+      minVersionCode: minVersionCode,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'versionName': versionName,
+      'versionCode': versionCode,
+      'apkUrl': apkUrl,
+      'tag': tag,
+      if (sha256 != null) 'sha256': sha256,
+      if (notes != null) 'notes': notes,
+      'mandatory': mandatory,
+      'minVersionCode': minVersionCode,
+    };
+  }
+
+  AppUpdateInfo copyWith({
+    String? versionName,
+    int? versionCode,
+    String? apkUrl,
+    String? tag,
+    String? sha256,
+    String? notes,
+    bool? mandatory,
+    int? minVersionCode,
+  }) {
+    return AppUpdateInfo(
+      versionName: versionName ?? this.versionName,
+      versionCode: versionCode ?? this.versionCode,
+      apkUrl: apkUrl ?? this.apkUrl,
+      tag: tag ?? this.tag,
+      sha256: sha256 ?? this.sha256,
+      notes: notes ?? this.notes,
+      mandatory: mandatory ?? this.mandatory,
+      minVersionCode: minVersionCode ?? this.minVersionCode,
+    );
+  }
+}

--- a/lib/providers/app_update_provider.dart
+++ b/lib/providers/app_update_provider.dart
@@ -1,0 +1,184 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:pstream_android/models/app_update_info.dart';
+import 'package:pstream_android/services/app_update_service.dart';
+
+enum AppUpdatePhase {
+  idle,
+  checking,
+  available,
+  upToDate,
+  downloading,
+  installing,
+  error,
+}
+
+class AppUpdateState {
+  const AppUpdateState({
+    this.phase = AppUpdatePhase.idle,
+    this.installedVersionName,
+    this.installedVersionCode,
+    this.available,
+    this.downloadProgress = 0,
+    this.errorMessage,
+  });
+
+  final AppUpdatePhase phase;
+  final String? installedVersionName;
+  final int? installedVersionCode;
+  final AppUpdateInfo? available;
+  final double downloadProgress;
+  final String? errorMessage;
+
+  bool get hasUpdate =>
+      available != null && phase == AppUpdatePhase.available;
+
+  AppUpdateState copyWith({
+    AppUpdatePhase? phase,
+    String? installedVersionName,
+    int? installedVersionCode,
+    AppUpdateInfo? available,
+    bool clearAvailable = false,
+    double? downloadProgress,
+    String? errorMessage,
+    bool clearError = false,
+  }) {
+    return AppUpdateState(
+      phase: phase ?? this.phase,
+      installedVersionName: installedVersionName ?? this.installedVersionName,
+      installedVersionCode: installedVersionCode ?? this.installedVersionCode,
+      available: clearAvailable ? null : (available ?? this.available),
+      downloadProgress: downloadProgress ?? this.downloadProgress,
+      errorMessage: clearError ? null : (errorMessage ?? this.errorMessage),
+    );
+  }
+}
+
+final appUpdateServiceProvider = Provider<AppUpdateService>((Ref ref) {
+  final AppUpdateService service = AppUpdateService();
+  ref.onDispose(service.dispose);
+  return service;
+});
+
+final installedPackageInfoProvider = FutureProvider<PackageInfo>((Ref ref) {
+  return ref.watch(appUpdateServiceProvider).installedPackageInfo();
+});
+
+final appUpdateControllerProvider =
+    StateNotifierProvider<AppUpdateController, AppUpdateState>((Ref ref) {
+  return AppUpdateController(ref.watch(appUpdateServiceProvider));
+});
+
+class AppUpdateController extends StateNotifier<AppUpdateState> {
+  AppUpdateController(this._service) : super(const AppUpdateState());
+
+  final AppUpdateService _service;
+
+  Future<void> loadInstalledVersion() async {
+    try {
+      final PackageInfo info = await _service.installedPackageInfo();
+      state = state.copyWith(
+        installedVersionName: info.version,
+        installedVersionCode: int.tryParse(info.buildNumber) ?? 0,
+      );
+    } catch (_) {
+      // Non-fatal; Settings still works without the label.
+    }
+  }
+
+  /// Quiet launch check (respects 24h throttle + dismissed version).
+  Future<void> checkOnLaunch() async {
+    await loadInstalledVersion();
+    await checkForUpdate(force: false, quiet: true);
+  }
+
+  Future<void> checkForUpdate({
+    bool force = true,
+    bool quiet = false,
+  }) async {
+    if (state.phase == AppUpdatePhase.checking ||
+        state.phase == AppUpdatePhase.downloading ||
+        state.phase == AppUpdatePhase.installing) {
+      return;
+    }
+
+    state = state.copyWith(
+      phase: AppUpdatePhase.checking,
+      clearError: true,
+    );
+
+    try {
+      await loadInstalledVersion();
+      final AppUpdateInfo? update = await _service.checkForUpdate(force: force);
+      if (update == null) {
+        state = state.copyWith(
+          phase: quiet ? AppUpdatePhase.idle : AppUpdatePhase.upToDate,
+          clearAvailable: true,
+        );
+        return;
+      }
+      state = state.copyWith(
+        phase: AppUpdatePhase.available,
+        available: update,
+      );
+    } catch (error) {
+      if (quiet) {
+        state = state.copyWith(
+          phase: AppUpdatePhase.idle,
+          clearError: true,
+        );
+        return;
+      }
+      state = state.copyWith(
+        phase: AppUpdatePhase.error,
+        errorMessage: error.toString(),
+      );
+    }
+  }
+
+  Future<void> downloadAndInstall() async {
+    final AppUpdateInfo? update = state.available;
+    if (update == null) {
+      return;
+    }
+
+    state = state.copyWith(
+      phase: AppUpdatePhase.downloading,
+      downloadProgress: 0,
+      clearError: true,
+    );
+
+    try {
+      await _service.downloadAndInstall(
+        update,
+        onProgress: (double progress) {
+          state = state.copyWith(
+            phase: AppUpdatePhase.downloading,
+            downloadProgress: progress,
+          );
+        },
+      );
+      state = state.copyWith(
+        phase: AppUpdatePhase.installing,
+        downloadProgress: 1,
+      );
+    } catch (error) {
+      state = state.copyWith(
+        phase: AppUpdatePhase.error,
+        errorMessage: error.toString(),
+      );
+    }
+  }
+
+  Future<void> dismissAvailableUpdate() async {
+    final AppUpdateInfo? update = state.available;
+    if (update != null) {
+      await _service.dismissUpdate(update);
+    }
+    state = state.copyWith(
+      phase: AppUpdatePhase.idle,
+      clearAvailable: true,
+      clearError: true,
+    );
+  }
+}

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:pstream_android/config/app_theme.dart';
 import 'package:pstream_android/config/breakpoints.dart';
+import 'package:pstream_android/models/app_update_info.dart';
+import 'package:pstream_android/providers/app_update_provider.dart';
 import 'package:pstream_android/providers/storage_provider.dart';
 import 'package:pstream_android/storage/local_storage.dart';
 
@@ -160,6 +163,8 @@ class SettingsScreen extends ConsumerWidget {
                 ],
               ),
             ),
+            const SizedBox(height: AppSpacing.x4),
+            const _AppUpdatesSection(),
           ],
         ),
       ),
@@ -204,6 +209,212 @@ class MediaStat {
 
   final String label;
   final int value;
+}
+
+class _AppUpdatesSection extends ConsumerWidget {
+  const _AppUpdatesSection();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final AppUpdateState updateState = ref.watch(appUpdateControllerProvider);
+    final AsyncValue<PackageInfo> packageInfo =
+        ref.watch(installedPackageInfoProvider);
+    final String versionLabel = packageInfo.when(
+      data: (PackageInfo info) => '${info.version} (${info.buildNumber})',
+      loading: () {
+        final String? name = updateState.installedVersionName;
+        final int? code = updateState.installedVersionCode;
+        if (name != null && code != null) {
+          return '$name ($code)';
+        }
+        return 'Reading…';
+      },
+      error: (Object _, StackTrace stackTrace) => 'Unknown',
+    );
+
+    return _SettingsSection(
+      title: 'App',
+      subtitle:
+          'Check GitHub Releases for a newer APK and install it over this build.',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          _SettingsActionTile(
+            icon: Icons.system_update_alt_rounded,
+            title: 'Check for updates',
+            subtitle: 'Installed $versionLabel',
+            actionLabel: updateState.phase == AppUpdatePhase.checking
+                ? 'Checking…'
+                : 'Check',
+            onTap: updateState.phase == AppUpdatePhase.checking ||
+                    updateState.phase == AppUpdatePhase.downloading
+                ? () {}
+                : () async {
+                    await ref
+                        .read(appUpdateControllerProvider.notifier)
+                        .checkForUpdate(force: true);
+                    if (!context.mounted) {
+                      return;
+                    }
+                    final AppUpdateState next =
+                        ref.read(appUpdateControllerProvider);
+                    if (next.phase == AppUpdatePhase.upToDate) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('You are up to date')),
+                      );
+                    } else if (next.phase == AppUpdatePhase.error &&
+                        next.errorMessage != null) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(content: Text(next.errorMessage!)),
+                      );
+                    }
+                  },
+          ),
+          if (updateState.available != null) ...<Widget>[
+            const SizedBox(height: AppSpacing.x3),
+            _UpdateAvailableCard(
+              update: updateState.available!,
+              phase: updateState.phase,
+              progress: updateState.downloadProgress,
+              errorMessage: updateState.errorMessage,
+              onInstall: () async {
+                await ref
+                    .read(appUpdateControllerProvider.notifier)
+                    .downloadAndInstall();
+                if (!context.mounted) {
+                  return;
+                }
+                final AppUpdateState next =
+                    ref.read(appUpdateControllerProvider);
+                if (next.phase == AppUpdatePhase.error &&
+                    next.errorMessage != null) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(content: Text(next.errorMessage!)),
+                  );
+                } else if (next.phase == AppUpdatePhase.installing) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text(
+                        'Opening installer — allow installs from Veil if prompted',
+                      ),
+                    ),
+                  );
+                }
+              },
+              onLater: () async {
+                await ref
+                    .read(appUpdateControllerProvider.notifier)
+                    .dismissAvailableUpdate();
+              },
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _UpdateAvailableCard extends StatelessWidget {
+  const _UpdateAvailableCard({
+    required this.update,
+    required this.phase,
+    required this.progress,
+    required this.onInstall,
+    required this.onLater,
+    this.errorMessage,
+  });
+
+  final AppUpdateInfo update;
+  final AppUpdatePhase phase;
+  final double progress;
+  final String? errorMessage;
+  final VoidCallback onInstall;
+  final VoidCallback onLater;
+
+  @override
+  Widget build(BuildContext context) {
+    final bool busy = phase == AppUpdatePhase.downloading ||
+        phase == AppUpdatePhase.installing;
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: AppColors.blackC150,
+        borderRadius: BorderRadius.circular(AppSpacing.x4 + AppSpacing.x1),
+        border: Border.all(color: AppColors.dropdownBorder),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.x4),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(
+              'Update available: ${update.versionName}',
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    color: AppColors.typeEmphasis,
+                    fontWeight: FontWeight.w700,
+                  ),
+            ),
+            const SizedBox(height: AppSpacing.x1),
+            Text(
+              'versionCode ${update.versionCode}'
+              '${update.mandatory ? ' · required' : ''}',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            if (update.notes != null && update.notes!.trim().isNotEmpty) ...<
+                Widget>[
+              const SizedBox(height: AppSpacing.x3),
+              Text(
+                update.notes!.trim(),
+                maxLines: 6,
+                overflow: TextOverflow.ellipsis,
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            ],
+            if (phase == AppUpdatePhase.downloading) ...<Widget>[
+              const SizedBox(height: AppSpacing.x3),
+              LinearProgressIndicator(value: progress.clamp(0, 1)),
+              const SizedBox(height: AppSpacing.x1),
+              Text(
+                'Downloading ${(progress * 100).clamp(0, 100).toStringAsFixed(0)}%',
+                style: Theme.of(context).textTheme.labelMedium,
+              ),
+            ],
+            if (errorMessage != null &&
+                phase == AppUpdatePhase.error) ...<Widget>[
+              const SizedBox(height: AppSpacing.x2),
+              Text(
+                errorMessage!,
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: AppColors.typeDanger,
+                    ),
+              ),
+            ],
+            const SizedBox(height: AppSpacing.x4),
+            Row(
+              children: <Widget>[
+                if (!update.mandatory)
+                  TextButton(
+                    onPressed: busy ? null : onLater,
+                    child: const Text('Later'),
+                  ),
+                const Spacer(),
+                FilledButton(
+                  onPressed: busy ? null : onInstall,
+                  child: Text(
+                    phase == AppUpdatePhase.installing
+                        ? 'Installing…'
+                        : phase == AppUpdatePhase.downloading
+                            ? 'Downloading…'
+                            : 'Download & install',
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
 }
 
 class _SettingsProfileHeader extends StatelessWidget {

--- a/lib/services/app_update_service.dart
+++ b/lib/services/app_update_service.dart
@@ -1,0 +1,271 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:http/http.dart' as http;
+import 'package:open_filex/open_filex.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:pstream_android/config/app_config.dart';
+import 'package:pstream_android/models/app_update_info.dart';
+import 'package:pstream_android/storage/local_storage.dart';
+
+/// Checks GitHub Releases for a newer Veil APK and installs it in-place.
+class AppUpdateService {
+  AppUpdateService({http.Client? client}) : _client = client ?? http.Client();
+
+  final http.Client _client;
+
+  static const Duration defaultCheckInterval = Duration(hours: 24);
+
+  Future<PackageInfo> installedPackageInfo() => PackageInfo.fromPlatform();
+
+  Future<int> installedVersionCode() async {
+    final PackageInfo info = await installedPackageInfo();
+    return int.tryParse(info.buildNumber) ?? 0;
+  }
+
+  /// Returns the latest published update when it is newer than the installed
+  /// build; otherwise `null`.
+  Future<AppUpdateInfo?> checkForUpdate({bool force = false}) async {
+    if (!force && !_shouldCheckNow()) {
+      return null;
+    }
+
+    final AppUpdateInfo? latest = await fetchLatestRelease();
+    await LocalStorage.setLastUpdateCheckAt(DateTime.now());
+
+    if (latest == null) {
+      return null;
+    }
+
+    final int installed = await installedVersionCode();
+    if (!latest.isNewerThan(installed)) {
+      return null;
+    }
+
+    final int? dismissed = LocalStorage.getDismissedUpdateVersionCode();
+    if (!force &&
+        !latest.mandatory &&
+        dismissed != null &&
+        dismissed >= latest.versionCode) {
+      return null;
+    }
+
+    return latest;
+  }
+
+  Future<AppUpdateInfo?> fetchLatestRelease() async {
+    final String? manifestUrl = AppConfig.updateManifestUrl;
+    if (manifestUrl != null && manifestUrl.isNotEmpty) {
+      return _fetchManifest(Uri.parse(manifestUrl));
+    }
+    return _fetchGithubLatestRelease();
+  }
+
+  Future<AppUpdateInfo?> _fetchManifest(Uri uri) async {
+    final http.Response response = await _client.get(
+      uri,
+      headers: const <String, String>{
+        'Accept': 'application/json',
+        'User-Agent': 'Veil-Android-Updater',
+      },
+    );
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw StateError(
+        'Update manifest HTTP ${response.statusCode}: ${response.body}',
+      );
+    }
+    final Object? decoded = jsonDecode(response.body);
+    if (decoded is! Map) {
+      throw const FormatException('Update manifest is not a JSON object');
+    }
+    final AppUpdateInfo info = AppUpdateInfo.fromJson(
+      Map<String, dynamic>.from(decoded),
+    );
+    if (info.apkUrl.isEmpty || info.versionCode <= 0) {
+      return null;
+    }
+    return info;
+  }
+
+  Future<AppUpdateInfo?> _fetchGithubLatestRelease() async {
+    final Uri uri = Uri.parse(
+      'https://api.github.com/repos/${AppConfig.updateGithubOwner}/'
+      '${AppConfig.updateGithubRepo}/releases/latest',
+    );
+    final http.Response response = await _client.get(
+      uri,
+      headers: const <String, String>{
+        'Accept': 'application/vnd.github+json',
+        'User-Agent': 'Veil-Android-Updater',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    );
+    if (response.statusCode == 404) {
+      return null;
+    }
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw StateError(
+        'GitHub releases HTTP ${response.statusCode}: ${response.body}',
+      );
+    }
+
+    final Object? decoded = jsonDecode(response.body);
+    if (decoded is! Map) {
+      throw const FormatException('GitHub release payload is not a JSON object');
+    }
+    final Map<String, dynamic> release = Map<String, dynamic>.from(decoded);
+    if (release['draft'] == true || release['prerelease'] == true) {
+      return null;
+    }
+
+    final List<dynamic> assets =
+        (release['assets'] as List<dynamic>?) ?? const <dynamic>[];
+    Map<String, dynamic>? versionJsonAsset;
+    Map<String, dynamic>? apkAsset;
+    for (final dynamic raw in assets) {
+      if (raw is! Map) {
+        continue;
+      }
+      final Map<String, dynamic> asset = Map<String, dynamic>.from(raw);
+      final String name = (asset['name'] ?? '').toString().toLowerCase();
+      if (name == 'version.json') {
+        versionJsonAsset = asset;
+      } else if (name == 'veil.apk' || name.endsWith('.apk')) {
+        apkAsset ??= asset;
+        if (name == 'veil.apk') {
+          apkAsset = asset;
+        }
+      }
+    }
+
+    if (versionJsonAsset != null) {
+      final String? url = versionJsonAsset['browser_download_url']?.toString();
+      if (url != null && url.isNotEmpty) {
+        final AppUpdateInfo? fromManifest = await _fetchManifest(Uri.parse(url));
+        if (fromManifest != null) {
+          return fromManifest.copyWith(
+            notes: fromManifest.notes ?? release['body']?.toString(),
+            tag: fromManifest.tag.isNotEmpty
+                ? fromManifest.tag
+                : (release['tag_name']?.toString() ?? ''),
+          );
+        }
+      }
+    }
+
+    if (apkAsset == null) {
+      return null;
+    }
+
+    final String tag = (release['tag_name'] ?? '').toString();
+    final String versionName = tag.startsWith('v') ? tag.substring(1) : tag;
+    final int versionCode = _versionCodeFromTagOrName(versionName);
+
+    return AppUpdateInfo(
+      versionName: versionName.isEmpty ? 'unknown' : versionName,
+      versionCode: versionCode,
+      apkUrl: apkAsset['browser_download_url']?.toString() ?? '',
+      tag: tag,
+      notes: release['body']?.toString(),
+    );
+  }
+
+  /// Downloads [update] to app cache, verifies SHA-256 when present, then
+  /// opens the system package installer.
+  Future<File> downloadAndInstall(
+    AppUpdateInfo update, {
+    void Function(double progress)? onProgress,
+  }) async {
+    if (update.apkUrl.isEmpty) {
+      throw StateError('Update APK URL is empty');
+    }
+
+    final Directory base = await getTemporaryDirectory();
+    final Directory dir = Directory('${base.path}/updates');
+    if (!await dir.exists()) {
+      await dir.create(recursive: true);
+    }
+    final File apkFile = File('${dir.path}/veil-${update.versionCode}.apk');
+    if (await apkFile.exists()) {
+      await apkFile.delete();
+    }
+
+    final http.Request request = http.Request('GET', Uri.parse(update.apkUrl));
+    request.headers['User-Agent'] = 'Veil-Android-Updater';
+    final http.StreamedResponse response = await _client.send(request);
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw StateError('APK download HTTP ${response.statusCode}');
+    }
+
+    final int? total = response.contentLength;
+    int received = 0;
+    final IOSink sink = apkFile.openWrite();
+    await for (final List<int> chunk in response.stream) {
+      sink.add(chunk);
+      received += chunk.length;
+      if (total != null && total > 0) {
+        onProgress?.call(received / total);
+      }
+    }
+    await sink.close();
+    onProgress?.call(1);
+
+    if (update.sha256 != null && update.sha256!.trim().isNotEmpty) {
+      final Digest digest = await sha256.bind(apkFile.openRead()).first;
+      final String actual = digest.toString();
+      if (actual.toLowerCase() != update.sha256!.trim().toLowerCase()) {
+        await apkFile.delete();
+        throw StateError(
+          'APK checksum mismatch (expected ${update.sha256}, got $actual)',
+        );
+      }
+    }
+
+    final OpenResult result = await OpenFilex.open(
+      apkFile.path,
+      type: 'application/vnd.android.package-archive',
+    );
+    if (result.type != ResultType.done) {
+      throw StateError(
+        result.message.isEmpty
+            ? 'Unable to open the package installer'
+            : result.message,
+      );
+    }
+    return apkFile;
+  }
+
+  Future<void> dismissUpdate(AppUpdateInfo update) {
+    return LocalStorage.setDismissedUpdateVersionCode(update.versionCode);
+  }
+
+  bool _shouldCheckNow() {
+    final DateTime? last = LocalStorage.getLastUpdateCheckAt();
+    if (last == null) {
+      return true;
+    }
+    return DateTime.now().difference(last) >= defaultCheckInterval;
+  }
+
+  /// Best-effort parse when version.json is missing: `1.0.2` → try pubspec
+  /// style is unavailable, so fall back to stripping non-digits from the
+  /// patch-ish form. Prefer attaching version.json from CI.
+  static int _versionCodeFromTagOrName(String versionName) {
+    final RegExpMatch? match = RegExp(
+      r'^(\d+)\.(\d+)\.(\d+)$',
+    ).firstMatch(versionName.trim());
+    if (match != null) {
+      final int major = int.parse(match.group(1)!);
+      final int minor = int.parse(match.group(2)!);
+      final int patch = int.parse(match.group(3)!);
+      return major * 10000 + minor * 100 + patch;
+    }
+    return int.tryParse(versionName.replaceAll(RegExp(r'[^0-9]'), '')) ?? 0;
+  }
+
+  void dispose() {
+    _client.close();
+  }
+}

--- a/lib/storage/local_storage.dart
+++ b/lib/storage/local_storage.dart
@@ -21,6 +21,9 @@ class LocalStorage {
   static const String prefKeySubtitleBgOpacity = 'pref_subtitle_bg_opacity';
   static const String prefKeyDoubleTapSeekSecs = 'pref_double_tap_seek_secs';
   static const String prefKeyHardwareAcceleration = 'pref_hardware_acceleration';
+  static const String prefKeyLastUpdateCheckAt = 'pref_last_update_check_at';
+  static const String prefKeyDismissedUpdateVersionCode =
+      'pref_dismissed_update_version_code';
 
   static const int doubleTapSeekDefaultSecs = 10;
   static const List<int> doubleTapSeekChoicesSecs = <int>[5, 10, 15, 30, 60];
@@ -32,7 +35,7 @@ class LocalStorage {
 
   // Subtitle style: stored as 0-100 ints / hex strings so Hive doesn't have
   // to track type adapters. Defaults match a comfortable mobile baseline.
-  static const int subtitleSizeDefault = 32; // media_kit `sub-font-size`
+  static const int subtitleSizeDefault = 32; // player subtitle overlay font size (pts)
   static const String subtitleColorDefault = '#FFFFFFFF';
   static const double subtitleBgOpacityDefault = 0.5;
 
@@ -304,7 +307,7 @@ class LocalStorage {
     await _prefsBox.put(prefKeySubtitlesDefaultOn, value);
   }
 
-  /// Subtitle font size in points (media_kit `sub-font-size`). Range 16–56.
+  /// Subtitle font size in points for the player overlay. Range 16–56.
   static int getSubtitleSize() {
     final dynamic raw = _prefsBox.get(prefKeySubtitleSize);
     if (raw is int) {
@@ -373,6 +376,38 @@ class LocalStorage {
 
   static Future<void> setHardwareAccelerationEnabled(bool value) async {
     await _prefsBox.put(prefKeyHardwareAcceleration, value);
+  }
+
+  /// Last successful in-app update check (UTC ISO-8601).
+  static DateTime? getLastUpdateCheckAt() {
+    final dynamic raw = _prefsBox.get(prefKeyLastUpdateCheckAt);
+    if (raw is! String || raw.isEmpty) {
+      return null;
+    }
+    return DateTime.tryParse(raw);
+  }
+
+  static Future<void> setLastUpdateCheckAt(DateTime value) async {
+    await _prefsBox.put(
+      prefKeyLastUpdateCheckAt,
+      value.toUtc().toIso8601String(),
+    );
+  }
+
+  /// Highest update [versionCode] the user dismissed with "Later".
+  static int? getDismissedUpdateVersionCode() {
+    final dynamic raw = _prefsBox.get(prefKeyDismissedUpdateVersionCode);
+    if (raw is int) {
+      return raw;
+    }
+    if (raw is String) {
+      return int.tryParse(raw);
+    }
+    return null;
+  }
+
+  static Future<void> setDismissedUpdateVersionCode(int value) async {
+    await _prefsBox.put(prefKeyDismissedUpdateVersionCode, value);
   }
 
   /// Aggregate watch statistics derived from existing boxes; no extra Hive

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -114,7 +114,7 @@ packages:
     source: hosted
     version: "0.3.5+2"
   crypto:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: crypto
       sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf
@@ -536,6 +536,14 @@ packages:
       url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.1.0"
+  open_filex:
+    dependency: "direct main"
+    description:
+      name: open_filex
+      sha256: "9976da61b6a72302cf3b1efbce259200cd40232643a467aac7370addf94d6900"
+      url: "https://pub.flutter-io.cn"
+    source: hosted
+    version: "4.7.0"
   package_config:
     dependency: transitive
     description:
@@ -544,6 +552,22 @@ packages:
       url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.2.0"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      sha256: "16eee997588c60225bda0488b6dcfac69280a6b7a3cf02c741895dd370a02968"
+      url: "https://pub.flutter-io.cn"
+    source: hosted
+    version: "8.3.1"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      url: "https://pub.flutter-io.cn"
+    source: hosted
+    version: "3.2.1"
   path:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: pstream_android
 description: "Veil is a minimalist Android streaming client with a self-hosted resolver stack."
 publish_to: 'none'
-version: 1.0.1+2
+version: 1.0.2+3
 
 environment:
   sdk: ^3.10.4
@@ -24,6 +24,9 @@ dependencies:
   file_picker: ^11.0.2
   path_provider: ^2.1.5
   flutter_inappwebview: ^6.0.0
+  package_info_plus: ^8.3.0
+  open_filex: ^4.7.0
+  crypto: ^3.0.6
 
 dev_dependencies:
   flutter_test:

--- a/test/app_update_info_test.dart
+++ b/test/app_update_info_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pstream_android/models/app_update_info.dart';
+
+void main() {
+  group('AppUpdateInfo', () {
+    test('parses version.json payload', () {
+      final AppUpdateInfo info = AppUpdateInfo.fromJson(<String, dynamic>{
+        'versionName': '1.0.2',
+        'versionCode': 3,
+        'apkUrl':
+            'https://github.com/dikshadamahe/veil-android/releases/download/v1.0.2/veil.apk',
+        'tag': 'v1.0.2',
+        'sha256': 'abc',
+        'mandatory': false,
+        'minVersionCode': 1,
+        'notes': 'Bug fixes',
+      });
+
+      expect(info.versionName, '1.0.2');
+      expect(info.versionCode, 3);
+      expect(info.isNewerThan(2), isTrue);
+      expect(info.isNewerThan(3), isFalse);
+      expect(info.sha256, 'abc');
+      expect(info.notes, 'Bug fixes');
+    });
+
+    test('copyWith preserves unset fields', () {
+      const AppUpdateInfo base = AppUpdateInfo(
+        versionName: '1.0.2',
+        versionCode: 3,
+        apkUrl: 'https://example.com/veil.apk',
+        tag: 'v1.0.2',
+        sha256: 'deadbeef',
+      );
+
+      final AppUpdateInfo next = base.copyWith(notes: 'Changelog');
+      expect(next.notes, 'Changelog');
+      expect(next.sha256, 'deadbeef');
+      expect(next.versionCode, 3);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Adds in-app update checking against GitHub Releases (`version.json` + `veil.apk`) with Settings UI and launch-time checks.
- Extends the APK Release workflow to require a stable upload keystore, publish `version.json` (with SHA-256), and attach signed APKs so installs can stack on top of each other.
- Bumps app version to `1.0.2+3` as the bootstrap build that can detect future releases.

## Test plan
- [ ] Add GitHub secrets: `ANDROID_KEYSTORE_BASE64`, `ANDROID_KEYSTORE_PASSWORD`, `ANDROID_KEY_ALIAS`, `ANDROID_KEY_PASSWORD` (plus existing `ORACLE_URL` / `TMDB_TOKEN`)
- [ ] Merge, tag `v1.0.2`, confirm Release workflow publishes `veil.apk` + `version.json`
- [ ] Install that APK, bump to `1.0.3+4`, tag `v1.0.3`, open Settings → App → Check for updates, download & install over the previous build
- [ ] Confirm Hive data (bookmarks/progress) survives the upgrade