### PR TITLE
fix(sports): drop const/null-aware on flutter_inappwebview v6 APIs

### DIFF
--- a/lib/utils/webview_ad_blocker.dart
+++ b/lib/utils/webview_ad_blocker.dart
@@ -254,7 +254,7 @@ iframe[src*="googlesyndication" i],
             trigger: ContentBlockerTrigger(
               urlFilter: _toUrlFilter(fragment),
             ),
-            action: const ContentBlockerAction(
+            action: ContentBlockerAction(
               type: ContentBlockerActionType.BLOCK,
             ),
           ),
@@ -314,7 +314,7 @@ iframe[src*="googlesyndication" i],
     }
 
     // Subframe / iframe loads: only cancel known ad URLs (handled above).
-    if (!(action.isForMainFrame ?? true)) {
+    if (!action.isForMainFrame) {
       return NavigationActionPolicy.ALLOW;
     }
 


### PR DESCRIPTION
ContentBlockerAction is not a const constructor in flutter_inappwebview 6, and NavigationAction.isForMainFrame is non-nullable, so the const invocation and the '?? true' fallback failed analyze. Both surfaced once WebViewAdBlocker was compiled into the sports embed path.